### PR TITLE
onboarding-mongodb-community-operator

### DIFF
--- a/data/mongodb-community-operator/bundle.yaml
+++ b/data/mongodb-community-operator/bundle.yaml
@@ -1,0 +1,637 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mongodb
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+    service.binding/type: 'mongodb'
+    service.binding/provider: 'community'
+    service.binding: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret'
+    service.binding/connectionString: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=connectionString.standardSrv'
+    service.binding/username: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=username'
+    service.binding/password: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=password'
+  creationTimestamp: null
+  namespace: mongodb
+  name: mongodbcommunity.mongodbcommunity.mongodb.com
+spec:
+  group: mongodbcommunity.mongodb.com
+  names:
+    kind: MongoDBCommunity
+    listKind: MongoDBCommunityList
+    plural: mongodbcommunity
+    shortNames:
+    - mdbc
+    singular: mongodbcommunity
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Current state of the MongoDB deployment
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Version of MongoDB server
+      jsonPath: .status.version
+      name: Version
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: MongoDBCommunity is the Schema for the mongodbs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MongoDBCommunitySpec defines the desired state of MongoDB
+            properties:
+              additionalMongodConfig:
+                description: 'AdditionalMongodConfig is additional configuration that
+                  can be passed to each data-bearing mongod at runtime. Uses the same
+                  structure as the mongod configuration file: https://www.mongodb.com/docs/manual/reference/configuration-options/'
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              arbiters:
+                description: 'Arbiters is the number of arbiters to add to the Replica
+                  Set. It is not recommended to have more than one arbiter per Replica
+                  Set. More info: https://www.mongodb.com/docs/manual/tutorial/add-replica-set-arbiter/'
+                type: integer
+              automationConfig:
+                description: AutomationConfigOverride is merged on top of the operator
+                  created automation config. Processes are merged by name. Currently
+                  Only the process.disabled field is supported.
+                properties:
+                  processes:
+                    items:
+                      description: OverrideProcess contains fields that we can override
+                        on the AutomationConfig processes.
+                      properties:
+                        disabled:
+                          type: boolean
+                        name:
+                          type: string
+                      required:
+                      - disabled
+                      - name
+                      type: object
+                    type: array
+                required:
+                - processes
+                type: object
+              featureCompatibilityVersion:
+                description: FeatureCompatibilityVersion configures the feature compatibility
+                  version that will be set for the deployment
+                type: string
+              members:
+                description: Members is the number of members in the replica set
+                type: integer
+              prometheus:
+                description: Prometheus configurations.
+                properties:
+                  metricsPath:
+                    description: Indicates path to the metrics endpoint.
+                    pattern: ^\/[a-z0-9]+$
+                    type: string
+                  passwordSecretRef:
+                    description: Name of a Secret containing a HTTP Basic Auth Password.
+                    properties:
+                      key:
+                        description: Key is the key in the secret storing this password.
+                          Defaults to "password"
+                        type: string
+                      name:
+                        description: Name is the name of the secret storing this user's
+                          password
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  port:
+                    description: Port where metrics endpoint will bind to. Defaults
+                      to 9216.
+                    type: integer
+                  tlsSecretKeyRef:
+                    description: Name of a Secret (type kubernetes.io/tls) holding
+                      the certificates to use in the Prometheus endpoint.
+                    properties:
+                      key:
+                        description: Key is the key in the secret storing this password.
+                          Defaults to "password"
+                        type: string
+                      name:
+                        description: Name is the name of the secret storing this user's
+                          password
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  username:
+                    description: HTTP Basic Auth Username for metrics endpoint.
+                    type: string
+                required:
+                - passwordSecretRef
+                - username
+                type: object
+              replicaSetHorizons:
+                description: ReplicaSetHorizons Add this parameter and values if you
+                  need your database to be accessed outside of Kubernetes. This setting
+                  allows you to provide different DNS settings within the Kubernetes
+                  cluster and to the Kubernetes cluster. The Kubernetes Operator uses
+                  split horizon DNS for replica set members. This feature allows communication
+                  both within the Kubernetes cluster and from outside Kubernetes.
+                items:
+                  additionalProperties:
+                    type: string
+                  type: object
+                type: array
+              security:
+                description: Security configures security features, such as TLS, and
+                  authentication settings for a deployment
+                properties:
+                  authentication:
+                    properties:
+                      ignoreUnknownUsers:
+                        default: true
+                        nullable: true
+                        type: boolean
+                      modes:
+                        description: Modes is an array specifying which authentication
+                          methods should be enabled.
+                        items:
+                          enum:
+                          - SCRAM
+                          - SCRAM-SHA-256
+                          - SCRAM-SHA-1
+                          type: string
+                        type: array
+                    required:
+                    - modes
+                    type: object
+                  roles:
+                    description: User-specified custom MongoDB roles that should be
+                      configured in the deployment.
+                    items:
+                      description: CustomRole defines a custom MongoDB role.
+                      properties:
+                        authenticationRestrictions:
+                          description: The authentication restrictions the server
+                            enforces on the role.
+                          items:
+                            description: AuthenticationRestriction specifies a list
+                              of IP addresses and CIDR ranges users are allowed to
+                              connect to or from.
+                            properties:
+                              clientSource:
+                                items:
+                                  type: string
+                                type: array
+                              serverAddress:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - clientSource
+                            - serverAddress
+                            type: object
+                          type: array
+                        db:
+                          description: The database of the role.
+                          type: string
+                        privileges:
+                          description: The privileges to grant the role.
+                          items:
+                            description: Privilege defines the actions a role is allowed
+                              to perform on a given resource.
+                            properties:
+                              actions:
+                                items:
+                                  type: string
+                                type: array
+                              resource:
+                                description: Resource specifies specifies the resources
+                                  upon which a privilege permits actions. See https://www.mongodb.com/docs/manual/reference/resource-document
+                                  for more.
+                                properties:
+                                  anyResource:
+                                    type: boolean
+                                  cluster:
+                                    type: boolean
+                                  collection:
+                                    type: string
+                                  db:
+                                    type: string
+                                type: object
+                            required:
+                            - actions
+                            - resource
+                            type: object
+                          type: array
+                        role:
+                          description: The name of the role.
+                          type: string
+                        roles:
+                          description: An array of roles from which this role inherits
+                            privileges.
+                          items:
+                            description: Role is the database role this user should
+                              have
+                            properties:
+                              db:
+                                description: DB is the database the role can act on
+                                type: string
+                              name:
+                                description: Name is the name of the role
+                                type: string
+                            required:
+                            - db
+                            - name
+                            type: object
+                          type: array
+                      required:
+                      - db
+                      - privileges
+                      - role
+                      type: object
+                    type: array
+                  tls:
+                    description: TLS configuration for both client-server and server-server
+                      communication
+                    properties:
+                      caCertificateSecretRef:
+                        description: CaCertificateSecret is a reference to a Secret
+                          containing the certificate for the CA which signed the server
+                          certificates The certificate is expected to be available
+                          under the key "ca.crt"
+                        properties:
+                          name:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      caConfigMapRef:
+                        description: CaConfigMap is a reference to a ConfigMap containing
+                          the certificate for the CA which signed the server certificates
+                          The certificate is expected to be available under the key
+                          "ca.crt" This field is ignored when CaCertificateSecretRef
+                          is configured
+                        properties:
+                          name:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      certificateKeySecretRef:
+                        description: CertificateKeySecret is a reference to a Secret
+                          containing a private key and certificate to use for TLS.
+                          The key and cert are expected to be PEM encoded and available
+                          at "tls.key" and "tls.crt". This is the same format used
+                          for the standard "kubernetes.io/tls" Secret type, but no
+                          specific type is required. Alternatively, an entry tls.pem,
+                          containing the concatenation of cert and key, can be provided.
+                          If all of tls.pem, tls.crt and tls.key are present, the
+                          tls.pem one needs to be equal to the concatenation of tls.crt
+                          and tls.key
+                        properties:
+                          name:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      enabled:
+                        type: boolean
+                      optional:
+                        description: Optional configures if TLS should be required
+                          or optional for connections
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                type: object
+              statefulSet:
+                description: StatefulSetConfiguration holds the optional custom StatefulSet
+                  that should be merged into the operator created one.
+                properties:
+                  spec:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                required:
+                - spec
+                type: object
+              type:
+                description: Type defines which type of MongoDB deployment the resource
+                  should create
+                enum:
+                - ReplicaSet
+                type: string
+              users:
+                description: Users specifies the MongoDB users that should be configured
+                  in your deployment
+                items:
+                  properties:
+                    connectionStringSecretName:
+                      description: ConnectionStringSecretName is the name of the secret
+                        object created by the operator which exposes the connection
+                        strings for the user. If provided, this secret must be different
+                        for each user in a deployment.
+                      type: string
+                    db:
+                      default: admin
+                      description: DB is the database the user is stored in. Defaults
+                        to "admin"
+                      type: string
+                    name:
+                      description: Name is the username of the user
+                      type: string
+                    passwordSecretRef:
+                      description: PasswordSecretRef is a reference to the secret
+                        containing this user's password
+                      properties:
+                        key:
+                          description: Key is the key in the secret storing this password.
+                            Defaults to "password"
+                          type: string
+                        name:
+                          description: Name is the name of the secret storing this
+                            user's password
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    roles:
+                      description: Roles is an array of roles assigned to this user
+                      items:
+                        description: Role is the database role this user should have
+                        properties:
+                          db:
+                            description: DB is the database the role can act on
+                            type: string
+                          name:
+                            description: Name is the name of the role
+                            type: string
+                        required:
+                        - db
+                        - name
+                        type: object
+                      type: array
+                    scramCredentialsSecretName:
+                      description: ScramCredentialsSecretName appended by string "scram-credentials"
+                        is the name of the secret object created by the mongoDB operator
+                        for storing SCRAM credentials These secrets names must be
+                        different for each user in a deployment.
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  - passwordSecretRef
+                  - roles
+                  - scramCredentialsSecretName
+                  type: object
+                type: array
+              version:
+                description: Version defines which version of MongoDB will be used
+                type: string
+            required:
+            - security
+            - type
+            - users
+            type: object
+          status:
+            description: MongoDBCommunityStatus defines the observed state of MongoDB
+            properties:
+              currentMongoDBArbiters:
+                type: integer
+              currentMongoDBMembers:
+                type: integer
+              currentStatefulSetArbitersReplicas:
+                type: integer
+              currentStatefulSetReplicas:
+                type: integer
+              message:
+                type: string
+              mongoUri:
+                type: string
+              phase:
+                type: string
+              version:
+                type: string
+            required:
+            - currentMongoDBMembers
+            - currentStatefulSetReplicas
+            - mongoUri
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    email: support@mongodb.com
+  labels:
+    owner: mongodb
+  namespace: mongodb
+  name: mongodb-kubernetes-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mongodb-kubernetes-operator
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: mongodb-kubernetes-operator
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - mongodb-kubernetes-operator
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command:
+        - /usr/local/bin/entrypoint
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: mongodb-kubernetes-operator
+        - name: AGENT_IMAGE
+          value: quay.io/mongodb/mongodb-agent:11.12.0.7388-1
+        - name: VERSION_UPGRADE_HOOK_IMAGE
+          value: quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.4
+        - name: READINESS_PROBE_IMAGE
+          value: quay.io/mongodb/mongodb-kubernetes-readinessprobe:1.0.8
+        - name: MONGODB_IMAGE
+          value: mongo
+        - name: MONGODB_REPO_URL
+          value: docker.io
+        image: quay.io/mongodb/mongodb-kubernetes-operator:0.7.3
+        imagePullPolicy: Always
+        name: mongodb-kubernetes-operator
+        resources:
+          limits:
+            cpu: 1100m
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 200Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 2000
+          allowPrivilegeEscalation: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: mongodb-kubernetes-operator
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: mongodb
+  name: mongodb-kubernetes-operator
+subjects:
+- kind: ServiceAccount
+  name: mongodb-kubernetes-operator
+roleRef:
+  kind: Role
+  name: mongodb-kubernetes-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: mongodb
+  name: mongodb-kubernetes-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: mongodb
+  name: mongodb-kubernetes-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - mongodbcommunity.mongodb.com
+  resources:
+  - mongodbcommunity
+  - mongodbcommunity/status
+  - mongodbcommunity/spec
+  - mongodbcommunity/finalizers
+  verbs:
+  - get
+  - patch
+  - list
+  - update
+  - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: mongodb
+  name: mongodb-database
+subjects:
+- kind: ServiceAccount
+  name: mongodb-database
+roleRef:
+  kind: Role
+  name: mongodb-database
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: mongodb
+  name: mongodb-database
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: mongodb
+  name: mongodb-database
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - patch
+      - delete
+      - get
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: mongodb
+  name: my-user-password
+type: Opaque
+stringData:
+  password: <your-password-here>

--- a/data/mongodb-community-operator/cr.yaml
+++ b/data/mongodb-community-operator/cr.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: mongodbcommunity.mongodb.com/v1
+kind: MongoDBCommunity
+metadata:
+  namespace: mongodb
+  name: mongodb-specify-pod-resources
+spec:
+  members: 3
+  type: ReplicaSet
+  version: "4.4.0"
+  security:
+    authentication:
+      modes: ["SCRAM"]
+  users:
+    - name: my-user
+      db: admin
+      passwordSecretRef: # a reference to the secret that will be used to generate the user's password
+        name: my-user-password
+      roles:
+        - name: clusterAdmin
+          db: admin
+        - name: userAdminAnyDatabase
+          db: admin
+      scramCredentialsSecretName: my-scram
+  statefulSet:
+    spec:
+      template:
+        spec:
+          # resources can be specified by applying an override
+          # per container name.
+          containers:
+            - name: mongod
+              resources:
+                limits:
+                  cpu: "0.2"
+                  memory: 250M
+                requests:
+                  cpu: "0.2"
+                  memory: 200M
+            - name: mongodb-agent
+              resources:
+                limits:
+                  cpu: "0.2"
+                  memory: 250M
+                requests:
+                  cpu: "0.2"
+                  memory: 200M
+# the user credentials will be generated from this secret
+# once the credentials are generated, this secret is no longer required
+#---
+#apiVersion: v1
+#kind: Secret
+#metadata:
+#  name: my-user-password
+#type: Opaque
+#stringData:
+#  password: <your-password-here>


### PR DESCRIPTION
## Introduction
I ported and used ACTO to test the [MongoDB Community Operator](https://github.com/mongodb/mongodb-kubernetes-operator). The required testrun directory can be accessed [here](https://drive.google.com/drive/folders/1uOpsVyk0cCXdiGxK4Fua3X3rgbCfAgG6?usp=sharing).

## Details
After running ACTO for the stipulated duration of one hour, a total of four trials were completed. Trials 0000, 0001 and 0003 are all similar true alarms. Trial 0002 is a false alarm.

# Trial-0002
This is a **False Alarm**.

## Result reported by ACTO:
```
{
      "trial_num": 2,
      "duration": "00:16:47",
      "num_tests": 3,
      "oracle": "SystemState",
      "message": "Found no matching fields for input",
      "input_delta": {
            "prev": false,
            "curr": true,
            "path": [
                  "spec",
                  "security",
                  "roles",
                  0,
                  "privileges",
                  0,
                  "resource",
                  "anyResource"
            ]
      },
      "matched_system_delta": null
}

```
The following change is made to the custom resource as part of the security specification by adding a new custom role first, and then, setting `anyResource: true`.
```
roles:
    - db: pjjrukfscd
      privileges:
      - actions:
        - ljyvgtcbcz
        - ijrkdqhyfc
        resource:
          anyResource: true
      role: aimqswmodx
```

Consequently, the operator fails at reconciliation. The mongodb agent fails to reach the goal state in test-cluster-0. 

## Found in operator log:

> Waiting for agents to reach version 3	{"ReplicaSet": "mongodb/test-cluster"}2022-06-19T09:42:03.434Z	DEBUG	agent/agent_readiness.go:65	The Agent in the Pod 'test-cluster-0' hasn't reached the goal state yet (goal: 3, agent: 2)	{"ReplicaSet": "mongodb/test-cluster"}2022-06-19T09:42:03.434Z	INFO	controllers/mongodb_status_options.go:110	ReplicaSet is not yet ready, retrying in 10 seconds

The reason for this is that the operator fails to create new roles. It finds the privilege strings that are added to the custom resource specification to be invalid. 

## Log for mongodb-agent in test-cluster-0:

> [2022-06-21T08:19:20.473+0000] [.error] [src/action/adjustroles.go:createRoles:121] <test-cluster-0> [08:19:20.473] Error creating role aimqswmodx@pjjrukfscd on db = pjjrukfscd (cmd = [{createRole aimqswmodx} {privileges [0xc0009814e0]} {roles []} {authenticationRestrictions []}]) : <test-cluster-0> [08:19:20.473] Error executing WithClientFor() for cp=test-cluster-0.test-cluster-svc.mongodb.svc.cluster.local:27017 (local=false) connectMode=SingleConnect : <test-cluster-0> [08:19:20.472] Error executing WithClientNoAtmUserFor() for cp=test-cluster-0.test-cluster-svc.mongodb.svc.cluster.local:27017 (local=false) connectMode=SingleConnect : <test-cluster-0> [08:19:20.472] Error running command for runCommandWithTimeout(dbName=pjjrukfscd, cmd=[{createRole aimqswmodx} {privileges [0xc0009814e0]} {roles []} {authenticationRestrictions []} {writeConcern map[w:majority]}]) : result=null identityUsed=__system@local[[MONGODB-CR/SCRAM-SHA-1 SCRAM-SHA-256]][668] : (FailedToParse) **Unrecognized action privilege strings: ljyvgtcbcz,ijrkdqhyfc**

These privilege strings are the actions that define the operations a user is allowed to perform on specified resources. These actions have to belong to the given set of [available actions](https://www.mongodb.com/docs/manual/reference/privilege-actions/).  

```
- ljyvgtcbcz
- ijrkdqhyfc
```
I think that because these action strings added by ACTO are not part of this set of available actions; therefore, this a false alarm.




# Trial-0000

~~This is a **True Alarm**.~~
This is a **False Alarm**.

## In order to reproduce behaviour:

1. Deploy the mongodb-community-operator using bundle.yaml file.
2. Deploy a simple test cluster using the following file
```
apiVersion: mongodbcommunity.mongodb.com/v1
kind: MongoDBCommunity
metadata:
  namespace: mongodb
  name: mongodb-specify-pod-resources
spec:
  members: 3
  type: ReplicaSet
  version: "4.4.0"
  security:
    authentication:
      modes: ["SCRAM"]
  users:
    - name: my-user
      db: admin
      passwordSecretRef: # a reference to the secret that will be used to generate the user's password
        name: my-user-password
      roles:
        - name: clusterAdmin
          db: admin
        - name: userAdminAnyDatabase
          db: admin
      scramCredentialsSecretName: my-scram
  statefulSet:
    spec:
      template:
        spec:
          # resources can be specified by applying an override
          # per container name.
          containers:
            - name: mongod
              resources:
                limits:
                  cpu: "0.2"
                  memory: 250M
                requests:
                  cpu: "0.2"
                  memory: 200M
            - name: mongodb-agent
              resources:
                limits:
                  cpu: "0.2"
                  memory: 250M
                requests:
                  cpu: "0.2"
                  memory: 200M

```
3. Change the yaml file by adding the following Prometheus configuration to the specification and apply the new configuration:
```
prometheus:
    passwordSecretRef:
      key: ncdnyexazo
      name: lctegagvvx
    username: cdlwallfah
```

## Error found in operator log:

> Error deploying MongoDB ReplicaSet: failed to ensure AutomationConfig: could not build automation config: could not enable TLS on Prometheus endpoint: could not configure Prometheus modification: Secret "lctegagvvx" not found

This indicates a problem with building the automation config. The root cause for this problem can be attributed to the absence of the following secret:

```
apiVersion: v1
kind: Secret
metadata:
 namespace: mongodb
 name: lctegagvvx
type: Opaque
stringData:
 ncdnyexazo : <my-password>
```

For ACTO to successfully test if the Prometheus configuration is applied without any issues, it is important that the secret the configuration refers to is already be created. However, I think that this resource is very specific to the change that ACTO introduces, so it should be responsible for creating this resource before applying the configuration (which would make this a false alarm). Although I don't think this is a problem with the operator itself, ~~I'm not sure so I'm considering this a true alarm~~.

# Trial-0019

This is a **True Alarm**.
[See here](https://github.com/xlab-uiuc/acto/pull/130#issuecomment-1183175211)