### PR TITLE
Add trial and generation information to log

### DIFF
--- a/acto_demo.py
+++ b/acto_demo.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import logging
 import signal
 import random
+from common import get_thread_logger
 
 from deploy import Deploy, DeployMethod
 from acto import handle_excepthook, Acto, timeout_handler
@@ -90,12 +91,13 @@ if __name__ == '__main__':
     # We don't need this now, but it would be nice to support this in the future
     # candidate_dict = construct_candidate_from_yaml(args.candidates)
     # logging.debug(candidate_dict)
+    logger = get_thread_logger(with_prefix=False)
 
-    logging.info('Acto started with [%s]' % sys.argv)
+    logger.info('Acto started with [%s]' % sys.argv)
 
     # Preload frequently used images to amid ImagePullBackOff
     if args.preload_images:
-        logging.info('%s will be preloaded into Kind cluster',
+        logger.info('%s will be preloaded into Kind cluster',
                      args.preload_images)
 
     # register timeout to automatically stop after # hours

--- a/checker.py
+++ b/checker.py
@@ -12,6 +12,7 @@ from compare import CompareMethods
 from input import InputModel
 from schema import ArraySchema, ObjectSchema
 from snapshot import EmptySnapshot, Snapshot
+from thread_logger import get_thread_logger
 from parse_log.parse_log import parse_log
 
 
@@ -331,9 +332,9 @@ class Checker(object):
         # the condition_value is stored as string in the json file
         condition_value = condition['value']
         if isinstance(value, int):
-            condition_value = int(condition_value)
+            condition_value = int(condition_value) if condition_value != None else None
         elif isinstance(value, float):
-            condition_value = float(condition_value)
+            condition_value = float(condition_value) if condition_value != None else None
         try:
             if translate_op(condition['op'])(value, condition_value):
                 return True

--- a/common.py
+++ b/common.py
@@ -1,3 +1,4 @@
+from asyncio.log import logger
 import enum
 import json
 import os
@@ -5,16 +6,14 @@ from typing import Tuple
 from deepdiff.helper import NotPresent
 from datetime import datetime, date
 import re
-import logging
 import string
 import random
 import subprocess
 import kubernetes
 import requests
 import operator
-import contextvars
-import threading
 
+from thread_logger import get_thread_logger
 from test_case import TestCase
 from deepdiff import DeepDiff
 
@@ -22,6 +21,7 @@ from deepdiff import DeepDiff
 def notify_crash(exception: str):
     import socket
     import sys
+    logger = get_thread_logger(with_prefix=True)
 
     hostname = socket.gethostname()
 
@@ -38,7 +38,7 @@ def notify_crash(exception: str):
             "Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.52 Safari/537.36"
     }
     r = requests.post(url, data=form_data, headers=user_agent)
-    logging.info('Send notify to google form')
+    logger.info('Send notify to google form')
 
 
 class DeployConfig:
@@ -291,6 +291,8 @@ def random_string(n: int):
 
 
 def save_result(trial_dir: str, trial_err: ErrorResult, num_tests: int, trial_elapsed):
+    logger = get_thread_logger(with_prefix=False)
+
     result_dict = {}
     try:
         trial_num = '-'.join(trial_dir.split('-')[-2:])
@@ -300,7 +302,7 @@ def save_result(trial_dir: str, trial_err: ErrorResult, num_tests: int, trial_el
     result_dict['duration'] = trial_elapsed
     result_dict['num_tests'] = num_tests
     if trial_err == None:
-        logging.info('Trial %s completed without error', trial_dir)
+        logger.info('Trial %s completed without error', trial_dir)
     else:
         result_dict['oracle'] = trial_err.oracle
         result_dict['message'] = trial_err.message
@@ -409,11 +411,13 @@ def kubectl(args: list,
             context_name: str,
             capture_output=False,
             text=False) -> subprocess.CompletedProcess:
+    logger = get_thread_logger(with_prefix=True)
+            
     cmd = ['kubectl']
     cmd.extend(args)
 
     if context_name == None:
-        logging.error('Missing context name for kubectl')
+        logger.error('Missing context name for kubectl')
     cmd.extend(['--context', context_name])
 
     p = subprocess.run(cmd, capture_output=capture_output, text=text)
@@ -421,11 +425,13 @@ def kubectl(args: list,
 
 
 def helm(args: list, context_name: str) -> subprocess.CompletedProcess:
+    logger = get_thread_logger(with_prefix=False)
+    
     cmd = ['helm']
     cmd.extend(args)
 
     if context_name == None:
-        logging.error('Missing cluster name for helm')
+        logger.error('Missing cluster name for helm')
     cmd.extend(['--kube-context', context_name])
 
     return subprocess.run(cmd, capture_output=True, text=True)
@@ -434,31 +440,6 @@ def helm(args: list, context_name: str) -> subprocess.CompletedProcess:
 def kubernetes_client(context_name: str) -> kubernetes.client.ApiClient:
     return kubernetes.config.kube_config.new_client_from_config(
         context=context_name)
-
-class PrefixLoggerAdapter(logging.LoggerAdapter):
-    """ A logger adapter that adds a prefix to every message """
-    def process(self, msg: str, kwargs: dict) -> Tuple[str, dict]:
-        return (f'[{self.extra["prefix"]}] ' + msg, kwargs)
-
-def set_thread_logger_prefix(prefix: str) -> None:
-    '''
-    Store the prefix in the thread local storag, 
-    invoke get_thread_logger_with_prefix to get the updated logger
-    '''
-    thread_local = threading.local()
-    thread_local.prefix = prefix
-
-def get_thread_logger(with_prefix: bool) -> logging.LoggerAdapter:
-    '''Get the logger with the prefix from the thread local storage'''
-    logger = logging.getLogger(threading.current_thread().name)
-    logger.setLevel(logging.DEBUG)
-    # if the prefix is not set, return the original logger
-    thread_local = threading.local()    
-    if not with_prefix or not hasattr(thread_local, 'prefix'):
-        return logger
-
-    return PrefixLoggerAdapter(logger, extra={'prefix': thread_local.prefix})
-
 
 if __name__ == '__main__':
     line = "sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.6/pkg/internal/controller/controller.go:214"

--- a/compare.py
+++ b/compare.py
@@ -1,9 +1,9 @@
 import base64
 from deepdiff.helper import NotPresent
 import configparser
-from common import get_thread_logger
 
 from k8s_util.k8sutil import canonicalizeQuantity
+from thread_logger import get_thread_logger
 
 
 class CompareMethods:

--- a/input.py
+++ b/input.py
@@ -12,8 +12,8 @@ import yaml
 from schema import extract_schema, BaseSchema, ObjectSchema, ArraySchema
 from testplan import TestPlan
 from value_with_schema import attach_schema_to_value
-from common import get_thread_logger, random_string
-
+from common import random_string
+from thread_logger import get_thread_logger
 
 class CustomField:
 

--- a/k8s_cluster/base.py
+++ b/k8s_cluster/base.py
@@ -1,9 +1,9 @@
 import subprocess
-import logging
 import time
 from abc import ABC, abstractmethod
 
 from constant import CONST
+from thread_logger import get_thread_logger
 
 
 class KubernetesCluster(ABC):
@@ -28,6 +28,8 @@ class KubernetesCluster(ABC):
         pass
 
     def restart_cluster(self, name: str, version: str):
+        logger = get_thread_logger(with_prefix=False)
+        
         retry_count = 3
 
         while (retry_count > 0):
@@ -36,9 +38,9 @@ class KubernetesCluster(ABC):
                 time.sleep(1)
                 self.create_cluster(name, version)
                 time.sleep(1)
-                logging.info('Created cluster')
+                logger.info('Created cluster')
             except Exception as e:
-                logging.warning(
+                logger.warning(
                     "%s happened when restarting cluster, retrying...", e)
                 retry_count -= 1
                 if retry_count == 0:
@@ -51,6 +53,8 @@ class KubernetesCluster(ABC):
         Args:
             1. name: name of the cluster name
         '''
+        logger = get_thread_logger(with_prefix=False)
+
         cmd = ['docker', 'ps', '--format', '{{.Names}}', '-f']
 
         if name == None:
@@ -63,5 +67,5 @@ class KubernetesCluster(ABC):
         if p.stdout == None or p.stdout == '':
             # no nodes can be found, returning an empty array
             return []
-        print("Container found:", p.stdout.strip().split('\n'))
+        logger.debug("Container found:", p.stdout.strip().split('\n'))
         return p.stdout.strip().split('\n')

--- a/parse_log/parse_log.py
+++ b/parse_log/parse_log.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import re
+from common import get_thread_logger
 
 klog_regex = r'^\s*'
 klog_regex += r'(\w)'  # group 1: level
@@ -55,6 +56,8 @@ def parse_log(line: str) -> dict:
     Returns:
         a dict containing 'level' and 'message'
     '''
+    logger = get_thread_logger(with_prefix=True)
+
     log_line = {}
     if re.search(klog_regex, line) != None:
         # log is in klog format
@@ -92,7 +95,7 @@ def parse_log(line: str) -> dict:
 
                 del log_line['severity']
         except Exception as e:
-            logging.warning(f"parse_log() cannot parse line {line} due to {e}")
+            logger.warning(f"parse_log() cannot parse line {line} due to {e}")
 
     return log_line
 

--- a/runner.py
+++ b/runner.py
@@ -10,6 +10,7 @@ import base64
 import acto_timer
 from snapshot import Snapshot
 from common import *
+from thread_logger import get_thread_logger
 
 
 class Runner(object):

--- a/schema.py
+++ b/schema.py
@@ -7,8 +7,9 @@ import json
 from jsonschema import validate
 
 from test_case import *
-from common import ActoEncoder, get_thread_logger, random_string
+from common import ActoEncoder, random_string
 from testplan import TreeNode
+from thread_logger import get_thread_logger
 
 
 class BaseSchema:

--- a/test_case.py
+++ b/test_case.py
@@ -1,6 +1,6 @@
 from typing import Callable
 
-from common import get_thread_logger
+from thread_logger import get_thread_logger
 
 
 class TestCase:
@@ -28,6 +28,7 @@ class TestCase:
 
     def test_precondition(self, prev) -> bool:
         logger = get_thread_logger(with_prefix=True)
+
         ret = True
         for additional_precondition in self.additional_preconditions:
             ret = ret and additional_precondition(prev)

--- a/testplan.py
+++ b/testplan.py
@@ -1,9 +1,8 @@
 import random
 import json
-from common import get_thread_logger
 
 from test_case import TestCase
-
+from thread_logger import get_thread_logger
 
 class TreeNode():
 

--- a/thread_logger.py
+++ b/thread_logger.py
@@ -1,0 +1,29 @@
+import logging
+import threading
+from typing import Tuple
+
+
+class PrefixLoggerAdapter(logging.LoggerAdapter):
+    """ A logger adapter that adds a prefix to every message """
+    def process(self, msg: str, kwargs: dict) -> Tuple[str, dict]:
+        return (f'[{self.extra["prefix"]}] {msg}', kwargs)
+
+logger_prefix = threading.local()
+
+def set_thread_logger_prefix(prefix: str) -> None:
+    '''
+    Store the prefix in the thread local storag, 
+    invoke get_thread_logger_with_prefix to get the updated logger
+    '''
+    logger_prefix.prefix = prefix
+
+def get_thread_logger(with_prefix: bool) -> logging.LoggerAdapter:
+    '''Get the logger with the prefix from the thread local storage'''
+    logger = logging.getLogger(threading.current_thread().name)
+    logger.setLevel(logging.DEBUG)
+    # if the prefix is not set, return the original logger
+    if not with_prefix or not hasattr(logger_prefix, 'prefix'):
+        return logger
+
+    return PrefixLoggerAdapter(logger, extra={'prefix': logger_prefix.prefix})
+

--- a/value_with_schema.py
+++ b/value_with_schema.py
@@ -2,10 +2,9 @@ from abc import abstractmethod
 import yaml
 import random
 import string
-from common import get_thread_logger
 
+from thread_logger import get_thread_logger
 from schema import AnyOfSchema, ObjectSchema, ArraySchema, StringSchema, NumberSchema, IntegerSchema, BooleanSchema, OpaqueSchema
-
 
 class ValueWithSchema():
 


### PR DESCRIPTION
### What is this PR?

This PR adds a configurable prefix for logging practices during runtime. This allows acto to add trial and generation information to each related log line.

It also fixes a bug where acto can crash when reading the field dependency map.

### Why making this PR?
When acto is doing parallel testing, multiple threads dump logs to the same file, which makes it hard to relate any specific log line to its corresponding trial and as a result, hard to understand the behavior of input generation and oracle. 

Before making this change, the log looks like:
```
2022-09-13 11:02:44,693 Thread-1    INFO   , root, runner.py:219, Waiting for system to converge... 
2022-09-13 11:02:45,169 Thread-2    INFO   , root, deploy.py:69, Operator ready
2022-09-13 11:02:45,170 Thread-2    INFO   , root, deploy.py:74, All pods took 30 seconds to get ready
``` 

After this change, the log will look like:
```
2022-09-13 11:02:44,693 INFO   , Thread-1 (run), runner.py:219, [trial: 2, gen: 3] Waiting for system to converge... 
2022-09-13 11:02:45,169  INFO   , Thread-2 (run), deploy.py:69, [trial: 3, gen 1] Operator ready
2022-09-13 11:02:45,170  INFO   , Thread-2 (run), deploy.py:74, [trial: 3, gen 1] All pods took 30 seconds to get ready
```
