### PR TITLE
Fix ApiException for previous container log

### DIFF
--- a/acto/runner/runner.py
+++ b/acto/runner/runner.py
@@ -246,11 +246,16 @@ class Runner(object):
                         if len(log) != 0:
                             with open(self.not_ready_pod_log_path.format(container_status.name), 'w') as f:
                                 f.write(log)
-                        log = self.coreV1Api.read_namespaced_pod_log(pod.metadata.name, self.namespace,
-                                                                     container=container_status.name, previous=True)
-                        if len(log) != 0:
-                            with open(self.not_ready_pod_log_path.format('prev-'+container_status.name), 'w') as f:
-                                f.write(log)
+                        if container_status.last_state.terminated is not None:
+                            try:
+                                log = self.coreV1Api.read_namespaced_pod_log(pod.metadata.name, self.namespace,
+                                                                            container=container_status.name, previous=True)
+                                if len(log) != 0:
+                                    with open(self.not_ready_pod_log_path.format('prev-'+container_status.name), 'w') as f:
+                                        f.write(log)
+                            except kubernetes.client.rest.ApiException as e:
+                                logger = get_thread_logger(with_prefix=True)
+                                logger.error('Failed to get previous log of pod %s' % pod.metadata.name, exc_info=e)
 
     def collect_cli_result(self, p: subprocess.CompletedProcess):
         cli_output = {}


### PR DESCRIPTION
fixes #244 

Fixes in this patch:
- Only try to fetch the previous container log if the container has terminated before
- Handle the ApiException for getting the log and write the exception to the Acto log