### PR TITLE
Minor Ansible fixes

### DIFF
--- a/scripts/ansible/acto.yaml
+++ b/scripts/ansible/acto.yaml
@@ -15,7 +15,7 @@
         archive: /tmp/acto.tar.gz
         clone: yes
         dest: /tmp/acto
-        repo: git@github.com:xlab-uiuc/acto.git
+        repo: https://github.com/xlab-uiuc/acto.git
         version: main
       run_once: true
 

--- a/scripts/ansible/configure.sh
+++ b/scripts/ansible/configure.sh
@@ -2,6 +2,7 @@
 ansible-playbook tmpfs.yaml -i ansible_hosts
 ansible-playbook go.yaml -i ansible_hosts
 ansible-playbook docker.yaml -i ansible_hosts
+ansible-playbook acto.yaml -i ansible_hosts
 ansible-playbook python.yaml -i ansible_hosts
 ansible-playbook kind.yaml -i ansible_hosts
 ansible-playbook kubectl.yaml -i ansible_hosts
@@ -10,4 +11,3 @@ ansible-playbook sysctl.yaml -i ansible_hosts
 ansible-playbook k3d.yaml -i ansible_hosts
 ansible-playbook k9s.yaml -i ansible_hosts
 ansible-playbook htop.yaml -i ansible_hosts
-ansible-playbook acto.yaml -i ansible_hosts

--- a/scripts/ansible/configure.yaml
+++ b/scripts/ansible/configure.yaml
@@ -10,7 +10,7 @@
 - name: Install go
   import_playbook: go.yaml
 
-- name: Install go
+- name: Install docker
   import_playbook: docker.yaml
 
 - name: Install python

--- a/scripts/ansible/configure.yaml
+++ b/scripts/ansible/configure.yaml
@@ -13,6 +13,9 @@
 - name: Install docker
   import_playbook: docker.yaml
 
+- name: Install acto
+  import_playbook: acto.yaml
+
 - name: Install python
   import_playbook: python.yaml
 
@@ -36,6 +39,3 @@
 
 - name: Install htop
   import_playbook: htop.yaml
-
-- name: Install acto
-  import_playbook: acto.yaml

--- a/scripts/ansible/python.yaml
+++ b/scripts/ansible/python.yaml
@@ -12,7 +12,13 @@
         state: present
         update_cache: yes
 
+    - name: Get the home directory
+      become: false
+      command: echo $HOME
+      register: home
+
     - name: Install python packages using pip
       pip:
-        name: "{{ PYTHON_PKGS }}"
+        # Implication: this script should happen after acto.yml
+        requirements: "{{ home.stdout }}/acto/requirements.txt"
         state: present


### PR DESCRIPTION
Since none of these are critical, I think we can discuss and test them after deadlines.

Details

- [x] Python: let Ansible honor `requirements.txt` at project root too
    I actually didn't know whether it was on purpose to maintain two sources of Python dependencies (`requirements.txt` and `data.yml`)? If so, we can still have e.g. `requirements/{common,dev,test,ansible}.txt`
- [x] Acto: now we should be able to directly clone the project via HTTPS
    One thing to determine, whatever protocol, is which branch/tag/commit to fetch?
    https://github.com/xlab-uiuc/acto/blob/4593e77d5162477fdcfcc919408de4d6f4214568/scripts/ansible/acto.yaml#L19
    Currently we always and only get the tip of `main` through archives -- probably not what we desire. Maybe it's not a big deal if we clone instead, because we will have to login those machines after all and can manually checkout. On the other hand, changing this value on a per-branch basis looks... awkward. I don't know if there's cleverer ways.
