### PR TITLE
Fix diff test index error

### DIFF
--- a/acto/post_process/post_diff_test.py
+++ b/acto/post_process/post_diff_test.py
@@ -366,7 +366,7 @@ class PostDiffTest(PostProcessor):
 
         self.all_inputs = []
         for trial, steps in self.trial_to_steps.items():
-            for step in steps:
+            for step in steps.values():
                 invalid, _ = step.runtime_result.is_invalid()
                 if invalid:
                     continue
@@ -486,7 +486,7 @@ class PostDiffTest(PostProcessor):
                     continue
 
                 trial_basename = os.path.basename(trial)
-                original_result = self.trial_to_steps[trial_basename][gen]
+                original_result = self.trial_to_steps[trial_basename][str(gen)]
                 step_result = PostDiffTest.check_diff_test_step(diff_test_result, original_result,
                                                                 self.config, False, runner)
                 if step_result is None:

--- a/acto/post_process/post_process.py
+++ b/acto/post_process/post_process.py
@@ -71,10 +71,10 @@ class Step:
         return self._runtime_result
 
 
-def read_trial_dir(trial_dir: str) -> List[Step]:
+def read_trial_dir(trial_dir: str) -> Dict[str, Step]:
     '''Read a trial directory and return a list of steps'''
 
-    steps: List[Step] = []
+    steps: Dict[str, Step] = {}
     for generation in range(0, 20):
         if not os.path.exists('%s/mutated-%d.yaml' % (trial_dir, generation)):
             break
@@ -83,7 +83,7 @@ def read_trial_dir(trial_dir: str) -> List[Step]:
         if step is None:
             continue
         else:
-            steps.append(step)
+            steps[str(generation)] = step
 
     return steps
 
@@ -132,7 +132,7 @@ class PostProcessor(object):
         # Initliaze trial dirs
         self._trials: List[str] = []
         self._trial_to_steps: Dict[str,
-                                   List[Step]] = {}  # trial_dir -> steps, key by trial_dir string
+                                   Dict[str, Step]] = {}  # trial_dir -> steps, key by trial_dir string
         trial_dirs = glob.glob(testrun_dir + '/*')
         for trial_dir in trial_dirs:
             if not os.path.isdir(trial_dir):
@@ -150,7 +150,7 @@ class PostProcessor(object):
         self._trials = value
 
     @property
-    def trial_to_steps(self) -> Dict[str, List[Step]]:
+    def trial_to_steps(self) -> Dict[str, Dict[str, Step]]:
         return self._trial_to_steps
 
     @property


### PR DESCRIPTION
This patch fixes an inconsistency of how the post_process reconstructs the testrun from files and how the Runner and Checker writes the files.
The root cause is that there could be some holes in the testrun files because of invalid inputs and reverts, and the fix is to index by dict key rather than using a list.

BTW, I think we need a clean interface for writing testrun info to disk and loading testrun info from disk, so that in the future this kind of implicit assumption between modules becomes explicit.