### PR TITLE
Fix reproduce command exception on missing acto namespace

### DIFF
--- a/acto/reproduce.py
+++ b/acto/reproduce.py
@@ -138,7 +138,7 @@ def repro_setup(v):
     return None
 
 
-def reproduce(workdir_path: str, reproduce_dir: str, operator_config: OperatorConfig, **kwargs) -> List[RunResult]:
+def reproduce(workdir_path: str, reproduce_dir: str, operator_config: OperatorConfig, acto_namespace: int, **kwargs) -> List[RunResult]:
     os.makedirs(workdir_path, exist_ok=True)
     # Setting up log infra
     logging.basicConfig(
@@ -169,7 +169,8 @@ def reproduce(workdir_path: str, reproduce_dir: str, operator_config: OperatorCo
                 is_reproduce=True,
                 input_model=input_model,
                 apply_testcase_f=apply_testcase_f,
-                reproduce_dir=reproduce_dir)
+                reproduce_dir=reproduce_dir,
+                acto_namespace=acto_namespace)
 
     errors = acto.run(modes=['normal'])
     return [error for error in errors if error is not None]
@@ -216,4 +217,3 @@ if __name__ == '__main__':
               operator_config=args.config,
               cluster_runtime=args.cluster_runtime)
     end_time = datetime.now()
-

--- a/acto/reproduce.py
+++ b/acto/reproduce.py
@@ -138,7 +138,7 @@ def repro_setup(v):
     return None
 
 
-def reproduce(workdir_path: str, reproduce_dir: str, operator_config: OperatorConfig, acto_namespace: int, **kwargs) -> List[RunResult]:
+def reproduce(workdir_path: str, reproduce_dir: str, operator_config: OperatorConfig, **kwargs) -> List[RunResult]:
     os.makedirs(workdir_path, exist_ok=True)
     # Setting up log infra
     logging.basicConfig(
@@ -169,8 +169,7 @@ def reproduce(workdir_path: str, reproduce_dir: str, operator_config: OperatorCo
                 is_reproduce=True,
                 input_model=input_model,
                 apply_testcase_f=apply_testcase_f,
-                reproduce_dir=reproduce_dir,
-                acto_namespace=acto_namespace)
+                reproduce_dir=reproduce_dir)
 
     errors = acto.run(modes=['normal'])
     return [error for error in errors if error is not None]
@@ -217,3 +216,4 @@ if __name__ == '__main__':
               operator_config=args.config,
               cluster_runtime=args.cluster_runtime)
     end_time = datetime.now()
+

--- a/acto/reproduce.py
+++ b/acto/reproduce.py
@@ -205,6 +205,11 @@ if __name__ == '__main__':
         dest='cluster_runtime',
         default="KIND",
         help='Cluster runtime for kubernetes, can be KIND (Default), K3D or MINIKUBE')
+    parser.add_argument(
+        '--acto-namespace',
+        dest='acto_namespace',
+        default=0,
+        help='Kubernetes namespace for acto')
     parser.add_argument('--context', dest='context', help='Cached context data')
     args = parser.parse_args()
 
@@ -215,5 +220,6 @@ if __name__ == '__main__':
     reproduce(workdir_path=workdir_path,
               reproduce_dir=args.reproduce_dir,
               operator_config=args.config,
+              acto_namespace=args.acto_namespace,
               cluster_runtime=args.cluster_runtime)
     end_time = datetime.now()


### PR DESCRIPTION
The reproduce command fails with `TypeError: reproduce() missing 1 required positional argument: 'acto_namespace'`

The fix is to remove the `acto_namespace` argument in the reproduce function because class `Acto` has a default value for the parameter.
