### PR TITLE
Modified e2e regression tests to reproduce only one bug

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,8 +1,8 @@
 name: End-to-End Test
 on:
   pull_request:
-  schedule:
-    - cron: '0 0 * * 0'  # Run every Sunday at 00:00 UTC
+  # schedule:
+  #   - cron: '0 0 * * 0'  # Run every Sunday at 00:00 UTC
 jobs:
   bug_reproduction:
     timeout-minutes: 1440
@@ -26,4 +26,4 @@ jobs:
           mkdir -m 777 -p profile/data
       - name: Run bug reproduction
         run: |
-          pytest -m "local"
+          pytest -m "regression"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -26,4 +26,4 @@ jobs:
           mkdir -m 777 -p profile/data
       - name: Run bug reproduction
         run: |
-          pytest -m "regression"
+          pytest -m "singleBugReproduction"

--- a/.github/workflows/python-syntax-checker.yml
+++ b/.github/workflows/python-syntax-checker.yml
@@ -30,7 +30,7 @@ jobs:
           make
       - name: Run unittest
         run: |
-          pytest -m "not local" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=acto | tee pytest-coverage.txt
+          pytest -m "not local and not singleBugReproduction" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=acto | tee pytest-coverage.txt
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
         with:

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -19,4 +19,4 @@ jobs:
           make
       - name: Run unittest
         run: |
-          pytest -m "not local"
+          pytest -m "not local and not singleBugReproduction"

--- a/acto/runner/runner.py
+++ b/acto/runner/runner.py
@@ -1,7 +1,7 @@
 import base64
 import queue
 import time
-from multiprocessing import Process, Queue
+from multiprocessing import Process, Queue, set_start_method, get_start_method
 
 import yaml
 
@@ -59,6 +59,9 @@ class Runner(object):
             'role': self.rbacAuthorizationV1Api.list_namespaced_role,
             'role_binding': self.rbacAuthorizationV1Api.list_namespaced_role_binding,
         }
+
+        if get_start_method() != "fork":
+            set_start_method("fork")
 
     def run(self, input: dict, generation: int) -> Tuple[Snapshot, bool]:
         '''Simply run the cmd and dumps system_state, delta, operator log, events and input files without checking. 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 markers =
     local: mark a test to run on a local machine
-    regression: mark a test to run e2e regressions on a pull request
+    singleBugReproduction: mark a test to run e2e regressions on a pull request

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     local: mark a test to run on a local machine
+    regression: mark a test to run e2e regressions on a pull request

--- a/test/test_bug_reproduction.py
+++ b/test/test_bug_reproduction.py
@@ -148,8 +148,8 @@ class TestBugReproduction(unittest.TestCase):
         
         self.assertFalse(errors, f'Test failed with {errors}')
 
-@pytest.mark.regression
-class TestRegression(unittest.TestCase):
+@pytest.mark.singleBugReproduction
+class TestSingleBugReproduction(unittest.TestCase):
 
     def __init__(self, methodName: str = "runTest") -> None:
         super().__init__(methodName)


### PR DESCRIPTION
The e2e regression tests on every PR were reproducing all the bugs and hence consuming a lot of time. Have modified it to reproduce only one bug (chosen at random).

![Screenshot from 2023-10-31 19-50-16](https://github.com/xlab-uiuc/acto/assets/42400749/54046a47-f85f-4c09-9e43-c43446a7616f)
