### PR TITLE
Add details to error operator log

### DIFF
--- a/acto/checker/impl/operator_log.py
+++ b/acto/checker/impl/operator_log.py
@@ -34,6 +34,7 @@ class OperatorLogChecker(CheckerInterface):
                 )
                 if is_invalid:
                     return InvalidInputResult(
+                        message=value,
                         responsible_property=invalid_field_path
                     )
             # We reported error if we found error in the operator log

--- a/acto/checker/impl/tests/test_operator_log.py
+++ b/acto/checker/impl/tests/test_operator_log.py
@@ -24,13 +24,16 @@ def checker_func(s: Snapshot, prev_s: Snapshot) -> Optional[InvalidInputResult]:
         enumerate(
             [
                 InvalidInputResult(
+                    message="StatefulSet.apps \"test-cluster-server\" is invalid: spec.template.spec.restartPolicy: Unsupported value: \"OnFailure\": supported values: \"Always\"",
                     responsible_property=PropertyPath([]),
                 ),
                 None,
                 InvalidInputResult(
+                    message="tidb cluster acto-namespace/test-cluster is not valid and must be fixed first, aggregated error: spec.tidb.volumeName: Invalid value: \"lsgqejeydt\": Can not find volumeName: lsgqejeydt in storageVolumes or additionalVolumes/additionalVolumeMounts",
                     responsible_property=PropertyPath([]),
                 ),
                 InvalidInputResult(
+                    message="github.com/rabbitmq/cluster-operator/controllers.(*RabbitmqClusterReconciler).Reconcile\n\t/workspace/controllers/rabbitmqcluster_controller.go:260\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.6/pkg/internal/controller/controller.go:298\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.6/pkg/internal/controller/controller.go:253\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.6/pkg/internal/controller/controller.go:214",
                     responsible_property=PropertyPath(
                         [
                             "spec",

--- a/acto/common.py
+++ b/acto/common.py
@@ -583,11 +583,13 @@ def invalid_input_message(
             - when log indicates invalid input: the responsible field path for the invalid input
     """
     logger = get_thread_logger(with_prefix=True)
+    is_invalid = False
 
     for regex in INVALID_INPUT_LOG_REGEX:
         if re.search(regex, log_msg):
             logger.info("Recognized invalid input through regex: %s", log_msg)
-            return True, PropertyPath([])
+            is_invalid = True
+            break
 
     # Check if the log line contains the field or value
     # If so, also return True
@@ -621,7 +623,7 @@ def invalid_input_message(
                 )
                 return True, delta.path
 
-    return False, PropertyPath([])
+    return is_invalid, PropertyPath([])
 
 
 def canonicalize(s: str):


### PR DESCRIPTION
Hi, while using acto, I found that in `results.csv`, the messages in the `Operator log` field are always `message='Invalid input detected' responsible_property=[]`

In `common.invalid_input_message`, the responsible field path will be missed when recognizing the log as an error.  I fixed it.
 
I also added the origin log message to `InvalidInputResult` so that it can be shown in `results.csv` for debugging.