### PR TITLE
Fix python version 3.10 being recognized as 3.1 for conditional_job

### DIFF
--- a/.github/workflows/counter.yml
+++ b/.github/workflows/counter.yml
@@ -39,7 +39,7 @@ jobs:
     - name: 'Set up Python'
       uses: actions/setup-python@v4
       with:
-          python-version: 3.10
+          python-version: '3.10'
     - name: Change bugs.md
       shell: bash
       run: python3 .github/workflows/bug_counter.py


### PR DESCRIPTION
fix failed CI https://github.com/xlab-uiuc/acto/commit/ed0fc72bf06677701697677dc6b48ab30a26d88f