### PR TITLE
modify reproduce bugs' CRs to fit Chameleon platform

### DIFF
--- a/test/cassop-315/inputs/mutated-0.yaml
+++ b/test/cassop-315/inputs/mutated-0.yaml
@@ -25,3 +25,6 @@ spec:
         requests:
           storage: 3Gi
       storageClassName: server-storage
+  configBuilderResources:
+    limits:
+      memory: "1Gi"

--- a/test/cassop-315/inputs/mutated-1.yaml
+++ b/test/cassop-315/inputs/mutated-1.yaml
@@ -27,3 +27,6 @@ spec:
         requests:
           storage: 3Gi
       storageClassName: server-storage
+  configBuilderResources:
+    limits:
+      memory: "1Gi"

--- a/test/cassop-315/inputs/mutated-2.yaml
+++ b/test/cassop-315/inputs/mutated-2.yaml
@@ -26,3 +26,6 @@ spec:
         requests:
           storage: 3Gi
       storageClassName: server-storage
+  configBuilderResources:
+    limits:
+      memory: "1Gi"

--- a/test/cassop-315/inputs/mutated-3.yaml
+++ b/test/cassop-315/inputs/mutated-3.yaml
@@ -30,3 +30,6 @@ spec:
         requests:
           storage: 3Gi
       storageClassName: server-storage
+  configBuilderResources:
+    limits:
+      memory: "1Gi"

--- a/test/cassop-330/trial-demo/mutated-0.yaml
+++ b/test/cassop-330/trial-demo/mutated-0.yaml
@@ -25,3 +25,6 @@ spec:
         requests:
           storage: 3Gi
       storageClassName: server-storage
+  configBuilderResources:
+    limits:
+      memory: "1Gi"

--- a/test/cassop-330/trial-demo/mutated-1.yaml
+++ b/test/cassop-330/trial-demo/mutated-1.yaml
@@ -29,3 +29,6 @@ spec:
         requests:
           storage: 3Gi
       storageClassName: server-storage
+  configBuilderResources:
+    limits:
+      memory: "1Gi"

--- a/test/cassop-330/trial-demo/mutated-2.yaml
+++ b/test/cassop-330/trial-demo/mutated-2.yaml
@@ -28,3 +28,6 @@ spec:
         requests:
           storage: 3Gi
       storageClassName: server-storage
+  configBuilderResources:
+    limits:
+      memory: "1Gi"

--- a/test/cassop-334/mutated-0.yaml
+++ b/test/cassop-334/mutated-0.yaml
@@ -25,3 +25,6 @@ spec:
         requests:
           storage: 3Gi
       storageClassName: server-storage
+  configBuilderResources:
+    limits:
+      memory: "1Gi"

--- a/test/cassop-334/mutated-1.yaml
+++ b/test/cassop-334/mutated-1.yaml
@@ -27,3 +27,6 @@ spec:
         requests:
           storage: 3Gi
       storageClassName: server-storage
+  configBuilderResources:
+    limits:
+      memory: "1Gi"

--- a/test/cassop-471/mutated-0.yaml
+++ b/test/cassop-471/mutated-0.yaml
@@ -25,3 +25,6 @@ spec:
         requests:
           storage: 3Gi
       storageClassName: server-storage
+  configBuilderResources:
+    limits:
+      memory: "1Gi"

--- a/test/cassop-471/mutated-1.yaml
+++ b/test/cassop-471/mutated-1.yaml
@@ -33,3 +33,6 @@ spec:
         key: node-role.kubernetes.io/control-plane
         operator: Exists
         tolerationSeconds: 3600
+  configBuilderResources:
+    limits:
+      memory: "1Gi"

--- a/test/cassop-471/mutated-2.yaml
+++ b/test/cassop-471/mutated-2.yaml
@@ -33,3 +33,6 @@ spec:
         key: node-role.kubernetes.io/control-plane
         operator: Exists
         tolerationSeconds: 7200
+  configBuilderResources:
+    limits:
+      memory: "1Gi"


### PR DESCRIPTION
The bugs of cass-operator cannot be reproduced due to OOMKilled. Adding resource limits to CRs resolve this issue.