### PR TITLE
correct the README and support podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ make
 
 To reproduce the bug, run the following command:
 ```sh
-python3 -m acto.reproduce --reproduce-dir test/cassop-330/trial-demo --config data/cass-operator/config.json
+python3 -m acto.reproduce --reproduce-dir test/e2e_tests/test_data/cassop-330/trial-demo --config data/cass-operator/config.json
 ```
 The files in the `test/cassop-330/trial-demo` directory are the sequence of CRs required to trigger
   this bug.

--- a/acto/engine.py
+++ b/acto/engine.py
@@ -812,6 +812,7 @@ class Acto:
 
         self.runner_type = Runner
         self.checker_type = CheckerSet
+        self.tool = os.getenv("IMAGE_TOOL", "docker")
 
         self.__learn(
             context_file=context_file,
@@ -1049,12 +1050,12 @@ class Acto:
             # first make sure images are present locally
             for image in self.context["preload_images"]:
                 subprocess.run(
-                    ["docker", "pull", image],
+                    [self.tool, "pull", image],
                     stdout=subprocess.DEVNULL,
                     check=True,
                 )
             subprocess.run(
-                ["docker", "image", "save", "-o", self.images_archive]
+                [self.tool, "image", "save", "-o", self.images_archive]
                 + list(self.context["preload_images"]),
                 stdout=subprocess.DEVNULL,
                 check=True,


### PR DESCRIPTION
Before this PR:
```console
  File "/Users/jiazha/goproject/acto/acto/reproduce.py", line 93, in __init__
    raise RuntimeError(
RuntimeError: No CRs found in test/cassop-330/trial-demo. CR file name should start with mutated-
...
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'docker'
```
After this PR:
```console
jiazha-mac:acto jiazha$ export IMAGE_TOOL=podman
jiazha-mac:acto jiazha$ python3 -m acto.reproduce --reproduce-dir test/e2e_tests/test_data/cassop-330/trial-demo --config data/cass-operator/config.json
```