### PR TITLE
Enable Acto to utilize examples when generating test values

### DIFF
--- a/acto/__main__.py
+++ b/acto/__main__.py
@@ -120,6 +120,7 @@ with open(args.config, "r", encoding="utf-8") as config_file:
     if "monkey_patch" in config:
         del config["monkey_patch"]
     config = OperatorConfig.model_validate(config)
+
 logger.info("Acto started with [%s]", sys.argv)
 logger.info("Operator config: %s", config)
 
@@ -137,7 +138,6 @@ acto = Acto(
     workdir_path=args.workdir_path,
     operator_config=config,
     cluster_runtime="KIND",
-    preload_images_=None,
     context_file=context_cache,
     helper_crd=args.helper_crd,
     num_workers=args.num_workers,
@@ -147,13 +147,12 @@ acto = Acto(
     is_reproduce=False,
     input_model=DeterministicInputModel,
     apply_testcase_f=apply_testcase_f,
-    delta_from=None,
     focus_fields=config.focus_fields,
 )
 generation_time = datetime.now()
 logger.info("Acto initialization finished in %s", generation_time - start_time)
 if not args.learn:
-    acto.run(modes=["normal"])
+    acto.run()
 normal_finish_time = datetime.now()
 logger.info("Acto normal run finished in %s", normal_finish_time - start_time)
 logger.info("Start post processing steps")

--- a/acto/input/input.py
+++ b/acto/input/input.py
@@ -4,10 +4,11 @@ import importlib
 import json
 import logging
 import operator
+import os
 import random
 import threading
 from functools import reduce
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 import pydantic
 import yaml
@@ -17,7 +18,7 @@ from acto.common import is_subfield
 from acto.input import k8s_schemas, property_attribute
 from acto.input.get_matched_schemas import find_matched_schema
 from acto.input.test_generators.generator import get_testcases
-from acto.schema import BaseSchema
+from acto.schema import BaseSchema, BooleanSchema, IntegerSchema
 from acto.schema.schema import extract_schema
 from acto.utils import get_thread_logger
 
@@ -67,7 +68,6 @@ class InputModel(abc.ABC):
     @abc.abstractmethod
     def generate_test_plan(
         self,
-        delta_from: Optional[str] = None,
         focus_fields: Optional[list] = None,
     ) -> dict:
         """Generate test plan based on CRD"""
@@ -116,7 +116,7 @@ class InputModel(abc.ABC):
     @abc.abstractmethod
     def next_test(
         self,
-    ) -> Optional[List[Tuple[TestGroup, tuple[str, TestCase]]]]:
+    ) -> Optional[list[Tuple[TestGroup, tuple[str, TestCase]]]]:
         """Selects next test case to run from the test plan
 
         Instead of random, it selects the next test case from the group.
@@ -157,7 +157,9 @@ class DeterministicInputModel(InputModel):
         self.example_dir = example_dir
         example_docs = []
         if self.example_dir is not None:
-            for example_filepath in glob.glob(self.example_dir + "*.yaml"):
+            for example_filepath in glob.glob(
+                os.path.join(self.example_dir, "*.yaml")
+            ):
                 with open(
                     example_filepath, "r", encoding="utf-8"
                 ) as example_file:
@@ -165,6 +167,8 @@ class DeterministicInputModel(InputModel):
                     for doc in docs:
                         example_docs.append(doc)
         for example_doc in example_docs:
+            logger = get_thread_logger(with_prefix=True)
+            logger.info("Loading example document %s", example_doc)
             self.root_schema.load_examples(example_doc)
 
         self.num_workers = num_workers
@@ -281,7 +285,6 @@ class DeterministicInputModel(InputModel):
 
     def generate_test_plan(
         self,
-        delta_from: Optional[str] = None,
         focus_fields: Optional[list] = None,
     ) -> dict:
         """Generate test plan based on CRD"""
@@ -303,6 +306,7 @@ class DeterministicInputModel(InputModel):
         num_semantic_test_cases = 0
         num_misoperations = 0
         num_pruned_test_cases = 0
+        missing_examples = []
         for path, test_case_list in test_cases:
             # First, check if the path is in the focus fields
             if focus_fields is not None:
@@ -313,6 +317,20 @@ class DeterministicInputModel(InputModel):
                         break
                 if not focused:
                     continue
+
+            schema = self.get_schema_by_path(path)
+            if (
+                not isinstance(schema, BooleanSchema)
+                and not isinstance(schema, IntegerSchema)
+                and len(schema.examples) == 0
+            ):
+                logger.info("No examples for %s", path)
+                info = [".".join(path), None if "description" not in schema.raw_schema else schema.raw_schema["description"],
+                                           "opaque" if "type" not in schema.raw_schema else schema.raw_schema["type"], 
+                                           None if "properties" not in schema.raw_schema else schema.raw_schema["properties"],
+                                           None if "required" not in schema.raw_schema else schema.raw_schema["required"]]
+                
+                missing_examples.append(info)
 
             path_str = (
                 json.dumps(path)
@@ -340,6 +358,18 @@ class DeterministicInputModel(InputModel):
 
             normal_testcases[path_str] = filtered_test_case_list
 
+        logger.info(
+            "There are %d properties that do not have examples",
+            len(missing_examples),
+        )
+        if self.example_dir is not None:
+            with open(
+                os.path.join(self.example_dir, "missing_fields.json"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                json.dump(missing_examples, f, indent=2)
+
         self.metadata.total_number_of_test_cases = num_test_cases
         self.metadata.number_of_run_test_cases = num_run_test_cases
         self.metadata.number_of_primitive_test_cases = num_pruned_test_cases
@@ -347,6 +377,7 @@ class DeterministicInputModel(InputModel):
         self.metadata.number_of_misoperations = num_misoperations
         self.metadata.number_of_pruned_test_cases = num_pruned_test_cases
 
+        logger.info("Got %d schemas to focus on", len(normal_testcases))
         logger.info("Generated %d test cases in total", num_test_cases)
         logger.info("Generated %d test cases to run", num_run_test_cases)
         logger.info(
@@ -395,7 +426,7 @@ class DeterministicInputModel(InputModel):
 
     def next_test(
         self,
-    ) -> Optional[List[Tuple[TestGroup, tuple[str, TestCase]]]]:
+    ) -> Optional[list[Tuple[TestGroup, tuple[str, TestCase]]]]:
         """Selects next test case to run from the test plan
 
         Instead of random, it selects the next test case from the group.

--- a/acto/input/test_generators/stateful_set.py
+++ b/acto/input/test_generators/stateful_set.py
@@ -58,7 +58,7 @@ def replicas_tests(schema: IntegerSchema) -> list[TestCase]:
         invalid=True,
         semantic=True,
     )
-    return [invalid_test, scale_down_up_test, scale_up_down_test, overload_test]
+    return [invalid_test, scale_down_up_test, scale_up_down_test]
 
 
 @test_generator(

--- a/acto/input/value_with_schema.py
+++ b/acto/input/value_with_schema.py
@@ -131,9 +131,9 @@ class ValueWithObjectSchema(ValueWithSchema):
                     else:
                         letters = string.ascii_lowercase
                         key = "".join(random.choice(letters) for i in range(5))
-                        self[
-                            key
-                        ] = self.schema.get_additional_properties().gen()
+                        self[key] = (
+                            self.schema.get_additional_properties().gen()
+                        )
                 else:
                     child_key = random.choice(
                         list(self.schema.get_properties())
@@ -175,20 +175,20 @@ class ValueWithObjectSchema(ValueWithSchema):
         """Ensures the path exists"""
         if len(path) == 0:
             return
-        key = path.pop(0)
+        key = path[0]
         if self.store is None:
             self.update(self.schema.gen(minimum=True))
             self[key] = None
         elif key not in self.store:
             self[key] = None
-        self.store[key].create_path(path)
+        self.store[key].create_path(path[1:])
 
     def set_value_by_path(self, value, path):
         if len(path) == 0:
             self.update(value)
         else:
-            key = path.pop(0)
-            self.store[key].set_value_by_path(value, path)
+            key = path[0]
+            self.store[key].set_value_by_path(value, path[1:])
 
     def __getitem__(self, key):
         return self.store[key]
@@ -206,7 +206,7 @@ class ValueWithObjectSchema(ValueWithSchema):
 class ValueWithArraySchema(ValueWithSchema):
     """Value with ArraySchema attached"""
 
-    def __init__(self, value, schema) -> None:
+    def __init__(self, value, schema: ArraySchema) -> None:
         self.schema = schema
         if value is None:
             self.store = None
@@ -306,7 +306,7 @@ class ValueWithArraySchema(ValueWithSchema):
         """Ensures the path exists"""
         if len(path) == 0:
             return
-        key = path.pop(0)
+        key = path[0]
         if self.store is None:
             self.store = []
             for _ in range(0, key):
@@ -316,14 +316,14 @@ class ValueWithArraySchema(ValueWithSchema):
             for _ in range(len(self.store), key):
                 self.append(None)
             self.append(None)
-        self.store[key].create_path(path)
+        self.store[key].create_path(path[1:])
 
     def set_value_by_path(self, value, path):
         if len(path) == 0:
             self.update(value)
         else:
-            key = path.pop(0)
-            self.store[key].set_value_by_path(value, path)
+            key = path[0]
+            self.store[key].set_value_by_path(value, path[1:])
 
     def __getitem__(self, key):
         return self.store[key]

--- a/acto/result.py
+++ b/acto/result.py
@@ -94,6 +94,15 @@ class InvalidInputResult(OracleResult):
     )
 
 
+class DeletionOracleResult(OracleResult):
+    """Model for the result of a deletion oracle run"""
+
+    message: str = pydantic.Field(
+        description="The message of the oracle run",
+        default="Deletion failed",
+    )
+
+
 class OracleResults(pydantic.BaseModel):
     """The results of a collection of oracles"""
 
@@ -117,6 +126,10 @@ class OracleResults(pydantic.BaseModel):
     )
     differential: Optional[DifferentialOracleResult] = pydantic.Field(
         description="The result of the differential oracle",
+        default=None,
+    )
+    deletion: Optional[OracleResult] = pydantic.Field(
+        description="The result of the deletion oracle",
         default=None,
     )
     custom: Optional[OracleResult] = pydantic.Field(

--- a/acto/schema/base.py
+++ b/acto/schema/base.py
@@ -149,7 +149,7 @@ class BaseSchema(SchemaInterface):
         self.raw_schema = schema
         self.default = None if "default" not in schema else schema["default"]
         self.enum = None if "enum" not in schema else schema["enum"]
-        self.examples: list[Any] = []
+        self.examples: set[Any] = set()
 
         self.attributes = PropertyAttribute(value=0)
         self.copied_over = False

--- a/acto/schema/integer.py
+++ b/acto/schema/integer.py
@@ -1,5 +1,5 @@
 import random
-from typing import Any, List, Tuple
+from typing import Any, List, Optional, Tuple
 
 from .base import BaseSchema, TreeNode
 from .number import NumberSchema
@@ -28,9 +28,9 @@ class IntegerSchema(NumberSchema):
     def to_tree(self) -> TreeNode:
         return TreeNode(self.path)
 
-    def load_examples(self, example: Any):
+    def load_examples(self, example: Optional[Any]):
         if isinstance(example, int):
-            self.examples.append(example)
+            self.examples.add(example)
 
     def set_default(self, instance):
         self.default = int(instance)

--- a/acto/schema/number.py
+++ b/acto/schema/number.py
@@ -1,5 +1,5 @@
 import random
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from .base import BaseSchema, TreeNode
 
@@ -59,8 +59,15 @@ class NumberSchema(BaseSchema):
     def to_tree(self) -> TreeNode:
         return TreeNode(self.path)
 
-    def load_examples(self, example: float):
-        self.examples.append(example)
+    def load_examples(self, example: Optional[float]):
+        if isinstance(example, float):
+            self.examples.add(example)
+        elif isinstance(example, int):
+            self.examples.add(example)
+        else:
+            raise TypeError(
+                f"Expected float, got {type(example)} for property {self.path}"
+            )
 
     def set_default(self, instance):
         self.default = float(instance)

--- a/acto/schema/opaque.py
+++ b/acto/schema/opaque.py
@@ -1,4 +1,7 @@
-from typing import List, Tuple
+from typing import Any, List, Optional, Tuple
+
+from acto.common import HashableDict, HashableList
+from acto.utils.thread_logger import get_thread_logger
 
 from .base import BaseSchema, TreeNode
 
@@ -17,8 +20,17 @@ class OpaqueSchema(BaseSchema):
     def to_tree(self) -> TreeNode:
         return TreeNode(self.path)
 
-    def load_examples(self, example):
-        pass
+    def load_examples(self, example: Optional[Any]):
+        if example is None:
+            return
+        logger = get_thread_logger(with_prefix=True)
+        logger.debug("Loading example %s into %s", example, self.path)
+        if isinstance(example, dict):
+            self.examples.add(HashableDict(example))
+        elif isinstance(example, list):
+            self.examples.add(HashableList(example))
+        else:
+            self.examples.add(example)
 
     def set_default(self, instance):
         self.default = instance

--- a/acto/schema/string.py
+++ b/acto/schema/string.py
@@ -1,9 +1,10 @@
 import random
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import exrex
 
 from acto.common import random_string
+from acto.utils.thread_logger import get_thread_logger
 
 from .base import BaseSchema, TreeNode
 
@@ -46,8 +47,16 @@ class StringSchema(BaseSchema):
     def to_tree(self) -> TreeNode:
         return TreeNode(self.path)
 
-    def load_examples(self, example: str):
-        self.examples.append(example)
+    def load_examples(self, example: Optional[str]):
+        if example is not None:
+            if isinstance(example, str):
+                logger = get_thread_logger(with_prefix=True)
+                logger.debug("Loading example %s into %s", example, self.path)
+                self.examples.add(example)
+            else:
+                raise TypeError(
+                    f"Expected string, got {type(example)} for {self.path}"
+                )
 
     def set_default(self, instance):
         self.default = str(instance)
@@ -55,7 +64,12 @@ class StringSchema(BaseSchema):
     def empty_value(self):
         return ""
 
-    def gen(self, exclude_value=None, minimum: bool = False, **kwargs):
+    def gen(
+        self,
+        exclude_value: Optional[str] = None,
+        minimum: bool = False,
+        **kwargs,
+    ):
         # TODO: Use minLength: the exrex does not support minLength
         if self.enum is not None:
             if exclude_value is not None:
@@ -64,12 +78,21 @@ class StringSchema(BaseSchema):
                 )
             else:
                 return random.choice(self.enum)
+        if self.examples:
+            if exclude_value is not None:
+                example_without_exclude = [
+                    x for x in self.examples if x != exclude_value
+                ]
+                if len(example_without_exclude) > 0:
+                    return random.choice(example_without_exclude)
+            else:
+                return random.choice(list(self.examples))
         if self.pattern is not None:
-            # XXX: since it's random, we don't need to exclude the value
+            # Since it's random, we don't need to exclude the value
             return exrex.getone(self.pattern, self.max_length)
         if minimum:
             return random_string(self.min_length)  # type: ignore
-        return "ACTOKEY"
+        return "ACTOSTRING"
 
     def __str__(self) -> str:
         return "String"

--- a/acto/utils/k8s_helper.py
+++ b/acto/utils/k8s_helper.py
@@ -3,89 +3,119 @@ from typing import Optional
 
 import kubernetes
 import yaml
-from kubernetes.client.models import (V1Deployment, V1Namespace, V1ObjectMeta,
-                                      V1Pod, V1StatefulSet)
+from kubernetes.client.models import (
+    V1Deployment,
+    V1Namespace,
+    V1ObjectMeta,
+    V1Pod,
+    V1StatefulSet,
+)
 
 from .thread_logger import get_thread_logger
 
 
 def is_pod_ready(pod: V1Pod) -> bool:
-    '''Check if the pod is ready
+    """Check if the pod is ready
 
     Args:
         pod: Pod object in kubernetes
 
     Returns:
         if the pod is ready
-    '''
+    """
     if pod.status is None or pod.status.conditions is None:
         return False
 
     for condition in pod.status.conditions:
-        if condition.type == 'Ready' and condition.status == 'True':
+        if condition.type == "Ready" and condition.status == "True":
             return True
     return False
 
 
 def get_deployment_available_status(deployment: V1Deployment) -> bool:
-    '''Get availability status from deployment condition
+    """Get availability status from deployment condition
 
     Args:
         deployment: Deployment object in kubernetes
 
     Returns:
         if the deployment is available
-    '''
+    """
     if deployment.status is None or deployment.status.conditions is None:
         return False
 
     for condition in deployment.status.conditions:
-        if condition.type == 'Available' and condition.status == 'True':
+        if condition.type == "Available" and condition.status == "True":
             return True
     return False
 
 
 def get_stateful_set_available_status(stateful_set: V1StatefulSet) -> bool:
-    '''Get availability status from stateful set condition
+    """Get availability status from stateful set condition
 
     Args:
         stateful_set: stateful set object in kubernetes
 
     Returns:
         if the stateful set is available
-    '''
+    """
     if stateful_set.status is None:
         return False
-    if stateful_set.status.replicas > 0 and stateful_set.status.current_replicas == stateful_set.status.replicas:
+    if (
+        stateful_set.status.replicas > 0
+        and stateful_set.status.current_replicas == stateful_set.status.replicas
+    ):
         return True
     return False
 
 
 def get_yaml_existing_namespace(fn: str) -> Optional[str]:
-    '''Get yaml's existing namespace
+    """Get yaml's existing namespace
 
     Args:
         fn (str): Yaml file path
 
     Returns:
         bool: True if yaml has namespace
-    '''
-    with open(fn, 'r') as operator_yaml:
-        parsed_operator_documents = yaml.load_all(operator_yaml,
-                                                  Loader=yaml.FullLoader)
+    """
+    with open(fn, "r", encoding="utf-8") as operator_yaml:
+        parsed_operator_documents = yaml.load_all(
+            operator_yaml, Loader=yaml.FullLoader
+        )
         for document in parsed_operator_documents:
-            if document != None and 'metadata' in document and 'namespace' in document['metadata']:
-                return document['metadata']['namespace']
+            if (
+                document is not None
+                and "metadata" in document
+                and "namespace" in document["metadata"]
+            ):
+                return document["metadata"]["namespace"]
+    return None
+
+
+def get_deployment_name_from_yaml(fn: str) -> Optional[str]:
+    """Get deployment name from yaml file"""
+    with open(fn, "r", encoding="utf-8") as operator_yaml:
+        parsed_operator_documents = yaml.load_all(
+            operator_yaml, Loader=yaml.FullLoader
+        )
+        for document in parsed_operator_documents:
+            if (
+                document is not None
+                and "kind" in document
+                and document["kind"] == "Deployment"
+            ):
+                return document["metadata"]["name"]
     return None
 
 
 def create_namespace(apiclient, name: str) -> V1Namespace:
     logger = get_thread_logger(with_prefix=False)
-    corev1Api = kubernetes.client.CoreV1Api(apiclient)
+    corev1_api = kubernetes.client.CoreV1Api(apiclient)
     namespace = None
     try:
-        namespace = corev1Api.create_namespace(
-            V1Namespace(metadata=V1ObjectMeta(name=name)))
+        namespace = corev1_api.create_namespace(
+            V1Namespace(metadata=V1ObjectMeta(name=name))
+        )
     except Exception as e:
         logger.error(e)
     return namespace
@@ -93,9 +123,9 @@ def create_namespace(apiclient, name: str) -> V1Namespace:
 
 def delete_namespace(apiclient, name: str) -> bool:
     logger = get_thread_logger(with_prefix=False)
-    corev1Api = kubernetes.client.CoreV1Api(apiclient)
+    corev1_api = kubernetes.client.CoreV1Api(apiclient)
     try:
-        corev1Api.delete_namespace(name=name)
+        corev1_api.delete_namespace(name=name)
     except Exception as e:
         logger.error(e)
         return False
@@ -105,22 +135,25 @@ def delete_namespace(apiclient, name: str) -> bool:
 def delete_operator_pod(apiclient, namespace: str) -> bool:
     logger = get_thread_logger(with_prefix=False)
 
-    coreV1Api = kubernetes.client.CoreV1Api(apiclient)
+    corev1_api = kubernetes.client.CoreV1Api(apiclient)
 
-    operator_pod_list = coreV1Api.list_namespaced_pod(
-        namespace=namespace, watch=False, label_selector="acto/tag=operator-pod").items
+    operator_pod_list = corev1_api.list_namespaced_pod(
+        namespace=namespace, watch=False, label_selector="acto/tag=operator-pod"
+    ).items
 
     if len(operator_pod_list) >= 1:
-        logger.debug('Got operator pod: pod name:' +
-                      operator_pod_list[0].metadata.name)
+        logger.debug(
+            "Got operator pod: pod name: %s", operator_pod_list[0].metadata.name
+        )
     else:
-        logger.error('Failed to find operator pod')
+        logger.error("Failed to find operator pod")
         return False
         # TODO: refine what should be done if no operator pod can be found
 
-    pod = coreV1Api.delete_namespaced_pod(name=operator_pod_list[0].metadata.name,
-                                          namespace=namespace)
-    if pod == None:
+    pod = corev1_api.delete_namespaced_pod(
+        name=operator_pod_list[0].metadata.name, namespace=namespace
+    )
+    if pod is None:
         return False
     else:
         time.sleep(10)

--- a/acto/utils/process_with_except.py
+++ b/acto/utils/process_with_except.py
@@ -4,7 +4,7 @@ from sys import excepthook
 
 
 class MyProcess(Process):
-    '''Process class with excepthook'''
+    """Process class with excepthook"""
 
     def run(self):
         try:

--- a/acto/utils/thread_logger.py
+++ b/acto/utils/thread_logger.py
@@ -1,31 +1,37 @@
 import logging
 import threading
-from typing import Tuple
+from typing import Union
 
 
 class PrefixLoggerAdapter(logging.LoggerAdapter):
-    """ A logger adapter that adds a prefix to every message """
-    def process(self, msg: str, kwargs: dict) -> Tuple[str, dict]:
-        return (f'[{self.extra["prefix"]}] {msg}', kwargs)
+    """A logger adapter that adds a prefix to every message"""
+
+    def process(self, msg: str, kwargs) -> tuple[str, dict]:
+        """Add the prefix to the message"""
+        if self.extra is not None and "prefix" in self.extra:
+            return (f'[{self.extra["prefix"]}] {msg}', kwargs)
+        return (msg, kwargs)
+
 
 logger_prefix = threading.local()
 
+
 def set_thread_logger_prefix(prefix: str) -> None:
-    '''
-    Store the prefix in the thread local storag, 
+    """
+    Store the prefix in the thread local storag,
     invoke get_thread_logger_with_prefix to get the updated logger
-    '''
+    """
     logger_prefix.prefix = prefix
 
-def get_thread_logger(with_prefix: bool) -> logging.LoggerAdapter:
-    '''Get the logger with the prefix from the thread local storage'''
+
+def get_thread_logger(
+    with_prefix: bool = True,
+) -> Union[logging.LoggerAdapter, logging.Logger]:
+    """Get the logger with the prefix from the thread local storage"""
     logger = logging.getLogger(threading.current_thread().name)
     logger.setLevel(logging.DEBUG)
     # if the prefix is not set, return the original logger
-    if not with_prefix or not hasattr(logger_prefix, 'prefix'):
+    if not with_prefix or not hasattr(logger_prefix, "prefix"):
         return logger
 
-    return PrefixLoggerAdapter(logger, extra={'prefix': logger_prefix.prefix})
-
-
-
+    return PrefixLoggerAdapter(logger, extra={"prefix": logger_prefix.prefix})

--- a/scripts/crawl_examples.py
+++ b/scripts/crawl_examples.py
@@ -1,12 +1,21 @@
+"""Crawls yaml examples from target repo as testing material"""
+
 import argparse
-import glob, os
+import glob
+import os
+
 import yaml
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Crawl CR examples in the project repo')
-
-    parser.add_argument('--dir', dest='dir', help='Project repo dir', required=True)
-    parser.add_argument('--kind', '-k', dest='kind', help='CR kind', required=True)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Crawl CR examples in the project repo"
+    )
+    parser.add_argument(
+        "--dir", dest="dir", help="Project repo dir", required=True
+    )
+    parser.add_argument(
+        "--kind", "-k", dest="kind", help="CR kind", required=False
+    )
     # parser.add_argument('--dest',
     #                     dest='dest',
     #                     help='Directory to store the crawlled examples',
@@ -14,18 +23,52 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    results = []
+    main_results = []
+    aux_results = []
 
-    for file in glob.glob(os.path.join(args.dir, '**', '*.yaml'), recursive=True):
-        with open(file, 'r') as yaml_file:
+    for file in glob.glob(
+        os.path.join(args.dir, "**", "*.yaml"), recursive=True
+    ):
+        with open(file, "r", encoding="utf-8") as yaml_file:
             try:
                 file_content = yaml.load(yaml_file, Loader=yaml.FullLoader)
-            except:
+            except yaml.YAMLError as e:
                 continue
-            if 'kind' in file_content and file_content['kind'] == args.kind:
-                print(file)
-                results.append(file_content)
+            if "kind" in file_content:
+                try:
+                    if file_content["namespace"] != "":
+                        file_content.pop("namespace", None)
+                except KeyError as e:
+                    print("No namespace, no op")
 
-    with open('examples.yaml', 'w') as out_file:
-        yaml.dump_all(results, out_file)
+                try:
+                    if file_content["metadata"]["namespace"] != "":
+                        file_content["metadata"].pop("namespace", None)
+                except KeyError as e:
+                    print("No metadata.namespace, no op")
 
+                try:
+                    if file_content["spec"]["datacenter"]["namespace"] != "":
+                        file_content["spec"]["datacenter"].pop(
+                            "namespace", None
+                        )
+                except KeyError as e:
+                    print("No spec.datacenter.namespace, no op")
+
+                if file_content["kind"] == "Deployment":
+                    continue
+                elif file_content["kind"] == args.kind:
+                    print(file)
+                    main_results.append(file_content)
+                elif file_content["kind"] == "StorageClass":
+                    print(file)
+                    file_content["provisioner"] = "rancher.io/local-path"
+                    aux_results.append(file_content)
+                elif file_content["kind"] != "CustomResourceDefinition":
+                    print(file)
+                    aux_results.append(file_content)
+
+    with open("examples.yaml", "w", encoding="utf-8") as out_file:
+        yaml.dump_all(main_results, out_file)
+    with open("aux-examples.yaml", "w", encoding="utf-8") as out_file:
+        yaml.dump_all(aux_results, out_file)

--- a/test/integration_tests/test_learn.py
+++ b/test/integration_tests/test_learn.py
@@ -37,7 +37,6 @@ class TestLearnPhase(unittest.TestCase):
             workdir_path=workdir_path,
             operator_config=config,
             cluster_runtime="KIND",
-            preload_images_=None,
             context_file=context_cache,
             helper_crd=None,
             num_workers=1,
@@ -47,6 +46,5 @@ class TestLearnPhase(unittest.TestCase):
             is_reproduce=False,
             input_model=DeterministicInputModel,
             apply_testcase_f=apply_testcase,
-            delta_from=None,
             focus_fields=config.focus_fields,
         )

--- a/test/integration_tests/test_semantic_tests.py
+++ b/test/integration_tests/test_semantic_tests.py
@@ -85,7 +85,7 @@ class TestSemanticTests(unittest.TestCase):
             custom_module_path=self.config.custom_module,
         )
 
-        input_model.generate_test_plan(delta_from=None, focus_fields=None)
+        input_model.generate_test_plan(focus_fields=None)
         input_model.set_worker_id(0)
         input_model.set_mode(InputModel.NORMAL)
 


### PR DESCRIPTION
This PR adds the capability to Acto to use the example values for the CRD properties when it generates values for them.

The examples can be provided as example CRs. Acto parses the example CRs and recursively add the example values in the example CRs to the CRD properties.