### PR TITLE
Support Acto to run with user provided Kubernetes cluster

### DIFF
--- a/acto/__main__.py
+++ b/acto/__main__.py
@@ -10,6 +10,7 @@ from datetime import datetime
 
 from acto.engine import Acto, apply_testcase
 from acto.input.input import DeterministicInputModel
+from acto.kubernetes_engine import base, kind, provided
 from acto.lib.operator_config import OperatorConfig
 from acto.post_process.post_diff_test import PostDiffTest
 from acto.utils.error_handler import handle_excepthook, thread_excepthook
@@ -133,11 +134,28 @@ else:
 
 apply_testcase_f = apply_testcase
 
+kubernetes_engine: base.KubernetesEngine
+if config.kubernetes_engine.self_provided:
+    kubernetes_engine = provided.ProvidedKubernetesEngine(
+        acto_namespace=0,
+        feature_gates=config.kubernetes_engine.feature_gates,
+        num_nodes=config.num_nodes,
+        version=config.kubernetes_version,
+        provided=config.kubernetes_engine.provided,
+    )
+else:
+    kubernetes_engine = kind.Kind(
+        acto_namespace=0,
+        feature_gates=config.kubernetes_engine.feature_gates,
+        num_nodes=config.num_nodes,
+        version=config.kubernetes_version,
+    )
+
 start_time = datetime.now()
 acto = Acto(
     workdir_path=args.workdir_path,
     operator_config=config,
-    cluster_runtime="KIND",
+    kubernetes_engine=kubernetes_engine,
     context_file=context_cache,
     helper_crd=args.helper_crd,
     num_workers=args.num_workers,

--- a/acto/common.py
+++ b/acto/common.py
@@ -5,7 +5,7 @@ import operator
 import random
 import re
 import string
-from typing import Any, Sequence, Tuple, TypeAlias, Union
+from typing import Any, Optional, Sequence, Tuple, TypeAlias, Union
 
 import deepdiff.model as deepdiff_model
 import kubernetes
@@ -391,7 +391,7 @@ GENERIC_FIELDS = [
 
 
 def kubernetes_client(
-    kubeconfig: str, context_name: str
+    kubeconfig: str, context_name: Optional[str]
 ) -> kubernetes.client.ApiClient:
     """Create a kubernetes client from kubeconfig and context name"""
     return kubernetes.config.kube_config.new_client_from_config(

--- a/acto/kubernetes_engine/base.py
+++ b/acto/kubernetes_engine/base.py
@@ -6,6 +6,7 @@ from typing import Callable, Optional
 import kubernetes
 
 from acto.constant import CONST
+from acto.lib.operator_config import SelfProvidedKubernetesConfig
 from acto.utils import get_thread_logger
 
 KubernetesEnginePostHookType = Callable[[kubernetes.client.ApiClient], None]
@@ -22,13 +23,17 @@ class KubernetesEngine(ABC):
         feature_gates: Optional[dict[str, bool]] = None,
         num_nodes=1,
         version="",
+        provided: Optional[SelfProvidedKubernetesConfig] = None,
     ) -> None:
         """Constructor for KubernetesEngine
 
         Args:
             acto_namespace: the namespace of the acto
             posthooks: a list of posthooks to be executed after the cluster is created
-            feature_gates: a list of feature gates to be enabled
+            feature_gates: a list of Kubernetes feature gates to be enabled
+            num_nodes: the number of nodes in the cluster
+            version: the version of Kubernetes
+            provided: the configuration for a self-provided Kubernetes engine
         """
 
     @abstractmethod
@@ -91,10 +96,10 @@ class KubernetesEngine(ABC):
                 continue
             break
 
-    def get_node_list(self, name: str):
+    def get_node_list(self, name: str) -> list[str]:
         """Fetch the name of worker nodes inside a cluster
         Args:
-            1. name: name of the cluster name
+            name: name of the cluster name
         """
         _ = get_thread_logger(with_prefix=False)
 

--- a/acto/kubernetes_engine/kind.py
+++ b/acto/kubernetes_engine/kind.py
@@ -2,7 +2,7 @@ import logging
 import os
 import subprocess
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import kubernetes
 import yaml
@@ -19,8 +19,8 @@ class Kind(base.KubernetesEngine):
     def __init__(
         self,
         acto_namespace: int,
-        posthooks: List[base.KubernetesEnginePostHookType] = None,
-        feature_gates: Dict[str, bool] = None,
+        posthooks: Optional[list[base.KubernetesEnginePostHookType]] = None,
+        feature_gates: Optional[dict[str, bool]] = None,
         num_nodes=1,
         version: Optional[str] = None,
     ):
@@ -140,7 +140,7 @@ class Kind(base.KubernetesEngine):
 
         if self._posthooks:
             for posthook in self._posthooks:
-                posthook(apiclient=apiclient)
+                posthook(apiclient)
 
     def load_images(self, images_archive_path: str, name: str):
         logging.info("Loading preload images")

--- a/acto/kubernetes_engine/provided.py
+++ b/acto/kubernetes_engine/provided.py
@@ -1,0 +1,113 @@
+import logging
+import subprocess
+from typing import Optional
+
+import kubernetes
+
+from acto.common import kubernetes_client, print_event
+from acto.constant import CONST
+
+from . import base
+
+
+class ProvidedKubernetesEngine(base.KubernetesEngine):
+    """KubernetesEngine for user-provided k8s cluster
+
+    Configuration for user-provided k8s cluster is very limited,
+    as it is assumed that the user has already set up the cluster.
+    Everything needs to be deployed in the ACTO_NAMESPACE to provide the
+    necessary isolation.
+    """
+
+    def __init__(
+        self,
+        acto_namespace: int,
+        posthooks: Optional[list[base.KubernetesEnginePostHookType]] = None,
+        feature_gates: Optional[dict[str, bool]] = None,
+        num_nodes: int = 1,
+        version: Optional[str] = None,
+        provided: Optional[base.SelfProvidedKubernetesConfig] = None,
+    ):
+        self._posthooks = posthooks
+
+        if feature_gates:
+            logging.error("Feature gates are not supported in provided k8s")
+
+        if num_nodes != 1:
+            logging.error("num_nodes is not supported in provided k8s")
+
+        if version:
+            logging.error("version is not supported in provided k8s")
+
+        if provided is None:
+            raise ValueError("Missing configuration for provided k8s")
+        self._kube_config = provided.kube_config
+        self._kube_context = provided.kube_context
+
+    def get_context_name(self, cluster_name: str) -> str:
+        """Returns the kubecontext based on the cluster name
+        KIND always adds `kind` before the cluster name
+        """
+        return self._kube_context
+
+    def create_cluster(self, name: str, kubeconfig: str):
+        """Does nothing as the cluster is already created
+        Args:
+            name: name of the cluster
+            config: path of the config file for cluster
+            version: k8s version
+        """
+        print_event("Connecting to a user-provided Kubernetes cluster...")
+
+        try:
+            kubernetes.config.load_kube_config(
+                config_file=self._kube_config, context=self._kube_context
+            )
+            apiclient = kubernetes_client(self._kube_config, self._kube_context)
+        except Exception as e:
+            logging.debug("Incorrect kube config file:")
+            with open(self._kube_config, encoding="utf-8") as f:
+                logging.debug(f.read())
+            raise e
+
+        if self._posthooks:
+            for posthook in self._posthooks:
+                posthook(apiclient)
+
+    def load_images(self, images_archive_path: str, name: str):
+        logging.info("Loading preload images")
+        cmd = ["kind", "load", "image-archive"]
+        if images_archive_path is None:
+            logging.warning(
+                "No image to preload, we at least should have operator image"
+            )
+
+        if name is not None:
+            cmd.extend(["--name", name])
+        else:
+            logging.error("Missing cluster name for kind load")
+
+        p = subprocess.run(cmd + [images_archive_path], check=False)
+        if p.returncode != 0:
+            logging.error("Failed to preload images archive")
+
+    def delete_cluster(self, name: str, kubeconfig: str):
+        """Cluster deletion via deleting the acto-namespace
+        Args:
+            name: name of the cluster
+            kubeconfig: path of the config file for cluster
+            kubecontext: context of the cluster
+        """
+        logging.info("Deleting cluster %s", name)
+        apiclient = kubernetes_client(self._kube_config, self._kube_context)
+        core_v1 = kubernetes.client.CoreV1Api(apiclient)
+        core_v1.delete_namespace(
+            CONST.ACTO_NAMESPACE, propagation_policy="Foreground"
+        )
+
+    def get_node_list(self, name: str) -> list[str]:
+        """We don't have a way to get the node list for a user-provided cluster
+        Args:
+            Name of the cluster
+        """
+        return []

--- a/test/integration_tests/test_kubernetes_engines.py
+++ b/test/integration_tests/test_kubernetes_engines.py
@@ -8,6 +8,8 @@ import pytest
 from acto.kubernetes_engine.base import KubernetesEngine
 from acto.kubernetes_engine.kind import Kind
 from acto.kubernetes_engine.minikube import Minikube
+from acto.kubernetes_engine.provided import ProvidedKubernetesEngine
+from acto.lib.operator_config import SelfProvidedKubernetesConfig
 
 testcases = [("kind", 4, "v1.27.3")]
 
@@ -43,3 +45,21 @@ def test_kubernetes_engines(cluster_type: str, num_nodes, version):
         # expect to raise RuntimeError
         # get_node_list should raise RuntimeError when cluster is not found
         cluster_instance.get_node_list(name)
+
+
+@pytest.mark.kubernetes_engine
+def test_user_provided_kubernetes():
+    """Test creating a user provided kubernetes cluster from Kind"""
+    config_path = os.path.join(os.path.expanduser("~"), ".kube/test-config")
+    name = "test-cluster"
+    cluster_instance = Kind(acto_namespace=0, num_nodes=1, version="v1.27.3")
+    cluster_instance.restart_cluster(name, config_path)
+
+    provided = ProvidedKubernetesEngine(
+        acto_namespace=0,
+        provided=SelfProvidedKubernetesConfig(
+            kube_config=config_path,
+            kube_context=cluster_instance.get_context_name(name),
+        ),
+    )
+    provided.create_cluster(name, config_path)

--- a/test/integration_tests/test_learn.py
+++ b/test/integration_tests/test_learn.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 from acto.engine import Acto, apply_testcase
 from acto.input.input import DeterministicInputModel
+from acto.kubernetes_engine import kind
 from acto.lib.operator_config import OperatorConfig
 
 test_dir = pathlib.Path(__file__).parent.resolve()
@@ -33,10 +34,17 @@ class TestLearnPhase(unittest.TestCase):
             os.path.dirname(config.seed_custom_resource), "context.json"
         )
 
+        kubernetes_engine = kind.Kind(
+            acto_namespace=0,
+            feature_gates=config.kubernetes_engine.feature_gates,
+            num_nodes=config.num_nodes,
+            version=config.kubernetes_version,
+        )
+
         Acto(
             workdir_path=workdir_path,
             operator_config=config,
-            cluster_runtime="KIND",
+            kubernetes_engine=kubernetes_engine,
             context_file=context_cache,
             helper_crd=None,
             num_workers=1,


### PR DESCRIPTION
Add a new implementation of the KubernetesEngine interface to support user-provided Kubernetes clusters. The user-provided Kubernetes cluster has limited configuration, since Acto does not have power to create it. 

It currently only supports to run with single worker. In the future, we can consider using namespaces for parallelizing the workload in a single cluster.