### PR TITLE
Chactos refactor and add a new network fault injection policy

### DIFF
--- a/chactos/cass-operator.json
+++ b/chactos/cass-operator.json
@@ -12,7 +12,7 @@
     "operator_selector": {
         "labelSelectors": {"name": "cass-operator"}
     },
-    "application_pod_prefix": "dev-dc1-",
     "application_data_dir": "/var/lib/cassandra/data",
-    "pod_failure_ratio": 0.6
+    "pod_failure_ratio": 0.6,
+    "fault_type": "pod_failure"
 }

--- a/chactos/failures/network_chaos.py
+++ b/chactos/failures/network_chaos.py
@@ -30,13 +30,17 @@ class OperatorApplicationPartitionFailure(Failure):
                 "name": "operator-application-partition",
             },
             "spec": {
-                "action": "partition",
+                "action": "loss",
                 "mode": "all",
                 "selector": self.operator_selector,
                 "direction": "both",
                 "target": {
                     "mode": "all",
                     "selector": self.app_selector,
+                },
+                "loss": {
+                    "correlation": "50",
+                    "losses": "50",
                 },
             },
         }

--- a/chactos/failures/pod_failures_chaos.py
+++ b/chactos/failures/pod_failures_chaos.py
@@ -1,6 +1,30 @@
+import math
+from typing import Optional, Self
+
+import kubernetes
 import yaml
 
 from chactos.failures.failure import Failure
+
+
+def build_label_selector(label_selector: dict) -> str:
+    """Build a label selector from a dict"""
+    return ",".join([f"{key}={value}" for key, value in label_selector.items()])
+
+
+def select_pods(
+    priority_pods: set[str], normal_pods: set[str], number: int
+) -> list[str]:
+    """Select a number of pods from the list of pods"""
+    selected_pods = []
+    for _ in range(number):
+        if len(priority_pods) > 0:
+            pod = priority_pods.pop()
+            normal_pods.discard(pod)
+        else:
+            pod = normal_pods.pop()
+        selected_pods.append(pod)
+    return selected_pods
 
 
 class PodFailure(Failure):
@@ -10,34 +34,89 @@ class PodFailure(Failure):
         self,
         selector: dict,
         namespace: str,
-        failure_ratio: int,
-        failure_index: int,
     ):
-        self.selector = selector
-        self.namespace = namespace
-        self.failure_ratio = failure_ratio
-        self.failure_index = failure_index
+        self._selector = selector
+        self._namespace = namespace
 
         super().__init__()
 
     def name(self) -> str:
-        """Get the name of the failure"""
-        return f"pod-crash-failure-{str(self.failure_ratio)}-{str(self.failure_index)}"
+        """Get the name of the failure
+
+        The name is unique by hashing on the tuple of the selector and namespace
+        """
+        return f"pod-crash-failure-{hash((self._selector, self._namespace))}"
+
+    @classmethod
+    def build_from_api(
+        cls,
+        api_client: kubernetes.client.ApiClient,
+        namespace: str,
+        pod_selector: dict,
+        failure_ratio: float = 1.0,
+        priority_pod_selector: Optional[dict] = None,
+    ) -> Self:
+        """Build a PodFailure dynamically from the Kubernetes API"""
+
+        # We need to dynamically select pods to inject faults
+        # Selecting pods to inject faults
+        priority_pod_names = set()
+        normal_pod_names = set()
+        core_v1_api = kubernetes.client.CoreV1Api(api_client)
+
+        if priority_pod_selector is not None:
+            # TODO: only support labelSelector right now
+            priority_label_selector = build_label_selector(
+                priority_pod_selector["labelSelectors"]
+            )
+            priority_pods = core_v1_api.list_namespaced_pod(
+                namespace=namespace,
+                watch=False,
+                label_selector=priority_label_selector,
+            ).items
+
+            for pod in priority_pods:
+                priority_pod_names.add(pod.metadata.name)
+
+        normal_selection_label = build_label_selector(
+            pod_selector["labelSelectors"]
+        )
+        normal_pods = core_v1_api.list_namespaced_pod(
+            namespace=namespace,
+            watch=False,
+            label_selector=normal_selection_label,
+        ).items
+        for pod in normal_pods:
+            normal_pod_names.add(pod.metadata.name)
+        num_total_pods = len(priority_pod_names | normal_pod_names)
+        num_pods_to_fail = math.ceil(num_total_pods * failure_ratio)
+        selected_pods = select_pods(
+            priority_pod_names,
+            normal_pod_names,
+            num_pods_to_fail,
+        )
+
+        return cls(
+            selector={
+                "pods": {namespace: selected_pods},
+                "namespaces": [namespace],
+            },
+            namespace=namespace,
+        )
 
     def to_dict(self) -> dict:
         """Dump the spec to a dict"""
-        failure_name = f"pod-crash-failure-{str(self.failure_ratio)}-{str(self.failure_index)}"
         return {
             "apiVersion": "chaos-mesh.org/v1alpha1",
             "kind": "PodChaos",
             "metadata": {
-                "name": failure_name,
+                "name": self.name(),
             },
             "spec": {
                 "action": "pod-failure",
                 "mode": "all",
                 "duration": "30s",
-                "selector": self.selector,
+                "selector": self._selector,
             },
         }
 

--- a/chactos/failures/pod_failures_chaos.py
+++ b/chactos/failures/pod_failures_chaos.py
@@ -1,3 +1,4 @@
+import json
 import math
 from typing import Optional
 
@@ -46,7 +47,8 @@ class PodFailure(Failure):
 
         The name is unique by hashing on the tuple of the selector and namespace
         """
-        return f"pod-crash-failure-{hash((self._selector, self._namespace))}"
+        h = hash((json.dumps(self._selector, sort_keys=True), self._namespace))
+        return f"pod-crash-failure-{h}"
 
     @classmethod
     def build_from_api(

--- a/chactos/failures/pod_failures_chaos.py
+++ b/chactos/failures/pod_failures_chaos.py
@@ -1,8 +1,9 @@
 import math
-from typing import Optional, Self
+from typing import Optional
 
 import kubernetes
 import yaml
+from typing_extensions import Self
 
 from chactos.failures.failure import Failure
 

--- a/chactos/fault_injection_config.py
+++ b/chactos/fault_injection_config.py
@@ -1,20 +1,14 @@
+import enum
 from typing import Optional
 
 import pydantic
 
 
-class KubernetesConfig(pydantic.BaseModel, extra="forbid"):
-    """Kubernetes Config"""
+class FaultType(enum.Enum):
+    """Fault Type"""
 
-    num_nodes: int = pydantic.Field(
-        description="Number of workers in the Kubernetes cluster", default=4
-    )
-    version: str = pydantic.Field(
-        default="v1.28.0", description="Kubernetes version"
-    )
-    feature_gates: Optional[dict[str, bool]] = pydantic.Field(
-        description="Path to the feature gates file", default=None
-    )
+    POD_FAILURE = "pod_failure"
+    NETWORK_DELAY = "network_failure"
 
 
 class FaultInjectionConfig(pydantic.BaseModel, extra="forbid"):
@@ -23,6 +17,6 @@ class FaultInjectionConfig(pydantic.BaseModel, extra="forbid"):
     application_selector: dict
     priority_application_selector: Optional[dict] = None
     operator_selector: dict
-    application_pod_prefix: str
     application_data_dir: str
-    pod_failure_ratio: Optional[float] = 1.0
+    pod_failure_ratio: float = 1.0
+    fault_type: FaultType

--- a/chactos/mariadb-operator.json
+++ b/chactos/mariadb-operator.json
@@ -5,6 +5,5 @@
     "operator_selector": {
         "labelSelectors": {"app.kubernetes.io/instance": "mariadb-operator"}
     },
-    "application_pod_prefix": "test-cluster-",
     "application_data_dir": "/var/lib/mysql"
 }

--- a/chactos/mariadb-operator.json
+++ b/chactos/mariadb-operator.json
@@ -5,5 +5,6 @@
     "operator_selector": {
         "labelSelectors": {"app.kubernetes.io/instance": "mariadb-operator"}
     },
-    "application_data_dir": "/var/lib/mysql"
+    "application_data_dir": "/var/lib/mysql",
+    "fault_type": "pod_failure"
 }

--- a/chactos/percona-mongodb-operator.json
+++ b/chactos/percona-mongodb-operator.json
@@ -5,5 +5,6 @@
     "operator_selector": {
         "labelSelectors": {"name": "percona-server-mongodb-operator"}
     },
-    "application_data_dir": "/data/db"
+    "application_data_dir": "/data/db",
+    "fault_type": "pod_failure"
 }

--- a/chactos/percona-mongodb-operator.json
+++ b/chactos/percona-mongodb-operator.json
@@ -5,6 +5,5 @@
     "operator_selector": {
         "labelSelectors": {"name": "percona-server-mongodb-operator"}
     },
-    "application_pod_prefix": "test-cluster-rs",
     "application_data_dir": "/data/db"
 }

--- a/chactos/rabbitmq-operator.json
+++ b/chactos/rabbitmq-operator.json
@@ -5,6 +5,5 @@
     "operator_selector": {
         "labelSelectors": {"app.kubernetes.io/name": "rabbitmq-cluster-operator"}
     },
-    "application_pod_prefix": "test-cluster-server-",
     "application_data_dir": "/var/lib/rabbitmq/mnesia"
 }

--- a/chactos/rabbitmq-operator.json
+++ b/chactos/rabbitmq-operator.json
@@ -5,5 +5,6 @@
     "operator_selector": {
         "labelSelectors": {"app.kubernetes.io/name": "rabbitmq-cluster-operator"}
     },
-    "application_data_dir": "/var/lib/rabbitmq/mnesia"
+    "application_data_dir": "/var/lib/rabbitmq/mnesia",
+    "fault_type": "pod_failure"
 }

--- a/chactos/strimzi-kafka-operator-zk.json
+++ b/chactos/strimzi-kafka-operator-zk.json
@@ -6,5 +6,6 @@
     "operator_selector": {
         "labelSelectors": {"name": "strimzi-cluster-operator"}
     },
-    "application_data_dir": "/var/lib/zookeeper"
+    "application_data_dir": "/var/lib/zookeeper",
+    "fault_type": "pod_failure"
 }

--- a/chactos/strimzi-kafka-operator-zk.json
+++ b/chactos/strimzi-kafka-operator-zk.json
@@ -6,6 +6,5 @@
     "operator_selector": {
         "labelSelectors": {"name": "strimzi-cluster-operator"}
     },
-    "application_pod_prefix": "test-cluster-zookeeper-",
     "application_data_dir": "/var/lib/zookeeper"
 }

--- a/chactos/strimzi-kafka-operator.json
+++ b/chactos/strimzi-kafka-operator.json
@@ -15,5 +15,6 @@
         }
     },
     "application_data_dir": "/var/lib/kafka/data-0",
-    "pod_failure_ratio": 0.6
+    "pod_failure_ratio": 0.6,
+    "fault_type": "pod_failure"
 }

--- a/chactos/strimzi-kafka-operator.json
+++ b/chactos/strimzi-kafka-operator.json
@@ -14,7 +14,6 @@
             "strimzi.io/kind": "cluster-operator"
         }
     },
-    "application_pod_prefix": "test-cluster-dual-role-",
     "application_data_dir": "/var/lib/kafka/data-0",
     "pod_failure_ratio": 0.6
 }

--- a/chactos/tidb-operator.json
+++ b/chactos/tidb-operator.json
@@ -5,5 +5,6 @@
     "operator_selector": {
         "labelSelectors": {"instance": "tidb-operator"}
     },
-    "application_data_dir": "/tmp/tikv/store"
+    "application_data_dir": "/tmp/tikv/store",
+    "fault_type": "pod_failure"
 }

--- a/chactos/tidb-operator.json
+++ b/chactos/tidb-operator.json
@@ -5,6 +5,5 @@
     "operator_selector": {
         "labelSelectors": {"instance": "tidb-operator"}
     },
-    "application_pod_prefix": "test-cluster-",
     "application_data_dir": "/tmp/tikv/store"
 }

--- a/chactos/zookeeper-operator.json
+++ b/chactos/zookeeper-operator.json
@@ -5,6 +5,5 @@
     "operator_selector": {
         "labelSelectors": {"name": "zookeeper-operator"}
     },
-    "application_pod_prefix": "test-cluster-",
     "application_data_dir": "/data"
 }

--- a/chactos/zookeeper-operator.json
+++ b/chactos/zookeeper-operator.json
@@ -5,5 +5,6 @@
     "operator_selector": {
         "labelSelectors": {"name": "zookeeper-operator"}
     },
-    "application_data_dir": "/data"
+    "application_data_dir": "/data",
+    "fault_type": "pod_failure"
 }


### PR DESCRIPTION
Refactor Chactos to follow better software engineering practice.

Add a network policy to randomly drop network messages between the operator and the application Pods.